### PR TITLE
Post-U3.2 fixes

### DIFF
--- a/Falcon BMS Alternative Launcher/AppRegInfo.cs
+++ b/Falcon BMS Alternative Launcher/AppRegInfo.cs
@@ -129,6 +129,8 @@ namespace FalconBMS.Launcher
             RegistryKey rk = Registry.LocalMachine.OpenSubKey(regName64, writable:false);
             if (rk == null) return false;
 
+            this.regName = regName64;
+
             this.installDir = (string)rk.GetValue("baseDir");
             if (String.IsNullOrEmpty(installDir)) return false;
 

--- a/Falcon BMS Alternative Launcher/Falcon BMS Alternative Launcher.csproj
+++ b/Falcon BMS Alternative Launcher/Falcon BMS Alternative Launcher.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Windows\CallsignWindow.xaml.cs">
       <DependentUpon>CallsignWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Windows\ITimerSink.cs" />
     <Compile Include="Windows\KeyMappingWindow.xaml.cs">
       <DependentUpon>KeyMappingWindow.xaml</DependentUpon>
     </Compile>

--- a/Falcon BMS Alternative Launcher/Input/AxAssgn.cs
+++ b/Falcon BMS Alternative Launcher/Input/AxAssgn.cs
@@ -9,7 +9,7 @@ namespace FalconBMS.Launcher.Input
     {
         // Member
         protected string axisName = "";     // ex:Roll, Pitch, Yaw etc...
-        protected DateTime assgnDate = DateTime.Parse("12/12/1998 12:00:00");
+        protected DateTime assgnDate = new DateTime(1998, 12, 12, 12, 0, 0);
         protected bool invert;
         protected AxCurve saturation = 0;
         protected AxCurve deadzone = 0;

--- a/Falcon BMS Alternative Launcher/Input/CommonConstants.cs
+++ b/Falcon BMS Alternative Launcher/Input/CommonConstants.cs
@@ -30,8 +30,8 @@ namespace FalconBMS.Launcher.Input
         public static readonly int AXISMIN = 0;
         public static readonly int AXISMAX = 65536;
 
-        public static readonly int FLUSHTIME1 = 1000;
-        public static readonly int FLUSHTIME2 = 1666;
+        public static readonly int FLUSHTIME1 = 900;
+        public static readonly int FLUSHTIME2 = 1500;
 
         public static readonly int BINAXISMIN = 0;
         public static readonly int BINAXISMAX = 15000;

--- a/Falcon BMS Alternative Launcher/Input/InGameAxAssgn.cs
+++ b/Falcon BMS Alternative Launcher/Input/InGameAxAssgn.cs
@@ -12,7 +12,7 @@ namespace FalconBMS.Launcher.Input
         protected bool invert;
         protected AxCurve saturation = AxCurve.None;
         protected AxCurve deadzone = AxCurve.None;
-        protected DateTime assgnDate = DateTime.Parse("12/12/1998 12:00:00");
+        protected DateTime assgnDate = new DateTime(1998, 12, 12, 12, 0, 0);
 
         public InGameAxAssgn() { }
 

--- a/Falcon BMS Alternative Launcher/Input/JoyAssgn.cs
+++ b/Falcon BMS Alternative Launcher/Input/JoyAssgn.cs
@@ -319,6 +319,9 @@ namespace FalconBMS.Launcher.Input
                     int povDir = dirId;
                     int soundId = pov[hatId].direction[dirId].GetSoundID((Pinky)shiftState);
 
+                    if (0 == String.CompareOrdinal(callback, "SimDoNothing"))
+                        povBlock.Append("# "); //NB: don't mask the code-default behavior which is thumblook
+
                     povBlock.AppendLine($"{callback} {povNumShifted} -1 -3 {povDir} 0x0 {soundId}");
                 }
             }

--- a/Falcon BMS Alternative Launcher/Program.cs
+++ b/Falcon BMS Alternative Launcher/Program.cs
@@ -15,6 +15,7 @@ namespace FalconBMS.Launcher
     {
         internal static string thisExeDir = null;
         internal static MainWindow mainWin = null;
+        internal static Window activeWin = null;
 
         [STAThread]
         public static void Main()
@@ -42,6 +43,22 @@ namespace FalconBMS.Launcher
                 Diagnostics.FinalizeLogfile();
             }
             return;
+        }
+
+        internal static bool? ShowDialogAndMakeActive(Window dialog)
+        {
+            Window prevActive = Program.activeWin;
+            dialog.Owner = prevActive;
+            try
+            {
+                Program.activeWin = dialog;
+                bool? result = dialog.ShowDialog();
+                return result;
+            }
+            finally
+            {
+                Program.activeWin = prevActive;
+            }
         }
 
         private static Assembly OnResolveAssembly(object sender, ResolveEventArgs args)

--- a/Falcon BMS Alternative Launcher/Properties/AssemblyInfo.cs
+++ b/Falcon BMS Alternative Launcher/Properties/AssemblyInfo.cs
@@ -48,5 +48,5 @@ using System.Windows;
 //
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 既定値にすることができます:
-[assembly: AssemblyVersion("2.4.1.5")]
-[assembly: AssemblyFileVersion("2.4.1.5")]
+[assembly: AssemblyVersion("2.4.1.6")]
+[assembly: AssemblyFileVersion("2.4.1.6")]

--- a/Falcon BMS Alternative Launcher/Windows/AxisAssignWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/AxisAssignWindow.xaml
@@ -8,7 +8,7 @@
         GlowBrush="Black" BorderThickness="0"
         Title="Axis Assign" Height="236" Width="512" 
         WindowStartupLocation="CenterScreen"
-        Loaded="AssignWindow_Loaded" Closed="AssignWindow_Closed" MouseDown="MetroWindow_MouseDown"
+        Loaded="AssignWindow_Loaded" MouseDown="MetroWindow_MouseDown"
         ResizeMode="NoResize" SizeToContent="Width" Topmost="True" 
         AllowDrop="False" ShowTitleBar="False" IsWindowDraggable="False" WindowStyle="None" Background="#bfc7cf">
     <Window.Resources>

--- a/Falcon BMS Alternative Launcher/Windows/CallsignWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/CallsignWindow.xaml.cs
@@ -47,7 +47,7 @@ namespace FalconBMS.Launcher.Windows
         public static void ShowCallsignWindow(AppRegInfo appReg)
         {
             CallsignWindow ownWindow = new CallsignWindow(appReg);
-            ownWindow.ShowDialog();
+            Program.ShowDialogAndMakeActive(ownWindow);
             return;
         }
 

--- a/Falcon BMS Alternative Launcher/Windows/ITimerSink.cs
+++ b/Falcon BMS Alternative Launcher/Windows/ITimerSink.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace FalconBMS.Launcher.Windows
+{
+    internal interface ITimerSink
+    {
+        void HandleTimerTick();
+    }
+}

--- a/Falcon BMS Alternative Launcher/Windows/KeyMappingWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/KeyMappingWindow.xaml
@@ -8,7 +8,7 @@
         GlowBrush="Black" BorderThickness="0"
         Title="Axis Assign" Height="236" Width="512" 
         WindowStartupLocation="CenterScreen"
-        Loaded="WindowLoaded" Closed="WindowClosed" MouseDown="WindowMouseDown"
+        Loaded="WindowLoaded" MouseDown="WindowMouseDown"
         ResizeMode="NoResize" SizeToContent="Width" Topmost="True" 
         AllowDrop="False" ShowTitleBar="False" IsWindowDraggable="False" WindowStyle="None" Background="#bfc7cf">
     <Window.Resources>

--- a/Falcon BMS Alternative Launcher/Windows/MainWindowAxisAssign.cs
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindowAxisAssign.cs
@@ -75,17 +75,8 @@ namespace FalconBMS.Launcher.Windows
 
         private ProgressBar tbprogressbar;
 
-        /// <summary>
-        /// Checks and shows each device each axis inputs 60 times per seconds.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        public void AxisMovingTimer_Tick(object sender, EventArgs e)
-        {
-            UpdateAxisStatus();
-        }
-
-        public void UpdateAxisStatus()
+        // Checks and shows each device each axis inputs 30 times per seconds.
+        internal void MainWindowAxisAssign_HandleTimerTick()
         {
             try
             {
@@ -333,9 +324,6 @@ namespace FalconBMS.Launcher.Windows
         /// <param name="e"></param>
         private void Assign_Click(object sender, RoutedEventArgs e)
         {
-            AxisMovingTimer.Stop();
-            NewDeviceDetectTimer.Stop();
-
             string whocalledwindow = ((System.Windows.Controls.Button)sender).Name;
 
             InGameAxAssgn axisAssign = AxisAssignWindow.ShowAxisAssignWindow(this, (InGameAxAssgn)inGameAxis[whocalledwindow], sender);
@@ -363,9 +351,6 @@ namespace FalconBMS.Launcher.Windows
             // Save the XML and Key files, after each change user makes.
             MainWindow.deviceControl.SaveXml();
             this.appReg.getOverrideWriter().SaveKeyMapping(MainWindow.inGameAxis, MainWindow.deviceControl);
-
-            NewDeviceDetectTimer.Start();
-            AxisMovingTimer.Start();
         }
         
         /// <summary>

--- a/Falcon BMS Alternative Launcher/Windows/MainWindowKeyMapping.cs
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindowKeyMapping.cs
@@ -116,9 +116,6 @@ namespace FalconBMS.Launcher.Windows
         /// <param name="e"></param>
         private void DataGrid_MouseButtonDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            KeyMappingTimer.Stop();
-            NewDeviceDetectTimer.Stop();
-
             KeyAssgn selectedItem = (KeyAssgn)KeyMappingGrid.SelectedItem;
             if (selectedItem == null)
                 return;
@@ -134,9 +131,6 @@ namespace FalconBMS.Launcher.Windows
 
             KeyMappingGrid.Items.Refresh();
             KeyMappingGrid.UnselectAllCells();
-
-            NewDeviceDetectTimer.Start();
-            KeyMappingTimer.Start();
         }
 
         private byte[] buttons;
@@ -173,11 +167,8 @@ namespace FalconBMS.Launcher.Windows
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        public void KeyMappingTimer_Tick(object sender, EventArgs e)
+        internal void MainWindowKeyMapping_HandleTimerTick()
         {
-            if (!this.IsActive)
-                return;
-
             try
             {
                 directInputDevice.GetCurrentKeyboardState();


### PR DESCRIPTION
Bump version to v2.4.1.6

Fix crash on startup for some locales (Korean?) when attempting to parse hardcoded datetime.

Reduce CPU load of multiple concurrent timers.

Allow the default pov-look behavior for unassigned pov-hat.

Fix compat with some 4.38 installations.