### PR TITLE
More post-U4 stuff

### DIFF
--- a/Falcon BMS Alternative Launcher/Input/CmdLineArgs.md
+++ b/Falcon BMS Alternative Launcher/Input/CmdLineArgs.md
@@ -16,7 +16,10 @@ Skips the movie during the opening splash screen sequence.  Equivalent to `set g
 Launch the 2D menu screen in borderless-window mode -- can help workaround or avoid compatibility problems launching directly into fullscreen-exclusive mode.
 
 -vr
-Launch BMS in VR mode.  See also `g_nVRHMD` config parameter.
+Launch BMS in Steam-VR mode.  (Overrides the `g_nVRHMD` config parameter.)
+
+-xr
+Launch BMS in OpenXR mode.  (Overrides the `g_nVRHMD` config parameter.)
 
 -novr
-Launch BMS in normal flatscreen (non-VR) mode.  (Overrides the `g_nVRHMD` config parameter.)
+Launch BMS in flatscreen (non-VR) mode.  (Overrides the `g_nVRHMD` config parameter.)

--- a/Falcon BMS Alternative Launcher/Input/CommonConstants.cs
+++ b/Falcon BMS Alternative Launcher/Input/CommonConstants.cs
@@ -56,6 +56,7 @@ namespace FalconBMS.Launcher.Input
         public static readonly string LOGCAT = "bms-logcat.exe";
         public static readonly string CFGFILE = "Falcon BMS.cfg";
         public static readonly string USERCFGFILE = "Falcon BMS User.cfg";
+        public static readonly string VRCFGFILE = "Falcon BMS VR.cfg";
 
         public static readonly string STOCKFOLDER = "/Stock/";
         public static readonly string CONFIGFOLDER = "/User/Config/";

--- a/Falcon BMS Alternative Launcher/Override/OverrideSetting.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSetting.cs
@@ -52,9 +52,6 @@ namespace FalconBMS.Launcher.Override
 
         protected virtual void SaveConfigfile(Hashtable inGameAxis, DeviceControl deviceControl)
         {
-            StreamWriter cfgBase = OverwriteCfg(CommonConstants.CFGFILE);
-            cfgBase.Close();
-
             using (StreamWriter cfgUser = OverwriteCfg(CommonConstants.USERCFGFILE))
             {
                 cfgUser.WriteLine(CommonConstants.CFGOVERRIDECOMMENTLINE);
@@ -62,7 +59,8 @@ namespace FalconBMS.Launcher.Override
                 OverrideButtonsPerDevice(cfgUser, deviceControl);
                 OverrideHotasPinkyShiftMagnitude(cfgUser, deviceControl);
                 OverridePovDeviceIDs(cfgUser, inGameAxis);
-                OverrideVRHMD(cfgUser);
+
+                ApplyVROverrides(cfgUser);
             }
         }
 
@@ -130,11 +128,45 @@ namespace FalconBMS.Launcher.Override
                 + " " + CommonConstants.CFGOVERRIDECOMMENT + "\r\n");
         }
 
-        protected virtual void OverrideVRHMD(StreamWriter cfg) { }
+        protected virtual void ApplyVROverrides(StreamWriter cfg)
+        {
+            bool isVR = false;
+            if (mainWindow.VR_SteamVR.IsVisible && mainWindow.VR_SteamVR.IsChecked == true)
+                isVR = true;
+            if (mainWindow.VR_OpenXR.IsVisible && mainWindow.VR_OpenXR.IsChecked == true)
+                isVR = true;
 
-        /// <summary>
-        /// As the name implies...
-        /// </summary>
+            if (!isVR) return;
+
+            string filename = appReg.GetInstallDir() + CommonConstants.CONFIGFOLDER + CommonConstants.VRCFGFILE;
+            if (!File.Exists(filename)) return;
+
+            using (StreamReader reader = new StreamReader(filename, Encoding.UTF8))
+            {
+                while (true)
+                {
+                    string line = reader.ReadLine();
+                    if (line == null) break;
+
+                    //TODO: refactor to remove duplicated code .. actually this whole VR-override feature should be ported over to native BMS.
+                    string lineTrimmed = line.Trim();
+                    if (lineTrimmed.Length == 0) continue;
+
+                    if (lineTrimmed.StartsWith("set"))
+                    {
+                        line = lineTrimmed;
+                        while (line.Contains("  "))
+                            line = line.Replace("  ", " "); //consecutive spaces break BMS parser (as of 4.37)
+                        while (line.Contains("\x201C") || line.Contains("\x201D")) //unicode smart-doublequotes
+                            line = line.Replace("\x201C", "\x0022").Replace("\x201D", "\x0022");
+                    }
+
+                    cfg.WriteLine(line + CommonConstants.CFGOVERRIDECOMMENT);
+                }
+            }
+            return;
+        }
+
         protected void SaveDeviceSorting(DeviceControl deviceControl)
         {
             // BMS overwrites DeviceSorting.txt if was written in UTF-8.

--- a/Falcon BMS Alternative Launcher/Override/OverrideSetting.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSetting.cs
@@ -93,6 +93,17 @@ namespace FalconBMS.Launcher.Override
                     if (line.Contains(CommonConstants.CFGOVERRIDECOMMENTLINE))
                         break; // read no more below this cutoff line
 
+                    // Trim leading/trailing whitespace, collapse consecutive whitespace chars, and replace unicode smart-doublequotes.
+                    string lineTrimmed = line.Trim();
+                    if (lineTrimmed.StartsWith("set"))
+                    {
+                        line = lineTrimmed;
+                        while (line.Contains("  "))
+                            line = line.Replace("  ", " "); //consecutive spaces break BMS parser (as of 4.37)
+                        while (line.Contains("\x201C") || line.Contains("\x201D")) //unicode smart-doublequotes
+                            line = line.Replace("\x201C", "\x0022").Replace("\x201D", "\x0022");
+                    }
+
                     lines.Add(line);
                 }
             }

--- a/Falcon BMS Alternative Launcher/Override/OverrideSettingFor437.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSettingFor437.cs
@@ -16,23 +16,6 @@ namespace FalconBMS.Launcher.Override
         {
         }
 
-        protected override void OverrideVRHMD(StreamWriter cfg)
-        {
-            if((bool)mainWindow.VR_SteamVR.IsChecked)
-            {
-                cfg.Write(
-                    "set g_nVRHMD 1"
-                    + CommonConstants.CFGOVERRIDECOMMENT + "\r\n");
-            }
-
-            if ((bool)mainWindow.VR_OpenXR.IsChecked)
-            {
-                cfg.Write(
-                    "set g_nVRHMD 2"
-                    + CommonConstants.CFGOVERRIDECOMMENT + "\r\n");
-            }
-        }
-
         protected override void SaveJoystickCal(Hashtable inGameAxis, DeviceControl deviceControl)
         {
             string filename = appReg.GetInstallDir() + CommonConstants.CONFIGFOLDER + "joystick.cal";

--- a/Falcon BMS Alternative Launcher/Properties/AssemblyInfo.cs
+++ b/Falcon BMS Alternative Launcher/Properties/AssemblyInfo.cs
@@ -48,5 +48,10 @@ using System.Windows;
 //
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 既定値にすることができます:
-[assembly: AssemblyVersion("2.4.1.9")]
-[assembly: AssemblyFileVersion("2.4.1.9")]
+#if DEBUG
+[assembly: AssemblyVersion("2.4.1.999")]
+[assembly: AssemblyFileVersion("2.4.1.999")]
+#else
+[assembly: AssemblyVersion("2.4.1.10")]
+[assembly: AssemblyFileVersion("2.4.1.10")]
+#endif

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
@@ -273,11 +273,9 @@ namespace FalconBMS.Launcher.Windows
 
         private void MainTimer_Tick(object sender, EventArgs e)
         {
-            // Don't burn CPU displaying input events, if our window is inactive.
-            Window activeWin = Program.activeWin;
-            if (!activeWin.IsActive) return;
-
             // Route event to the currently active window (dialog/popups).
+            Window activeWin = Program.activeWin;
+
             ITimerSink timerSink = activeWin as ITimerSink;
             if (timerSink == null) return;
 

--- a/Falcon BMS Alternative Launcher/Windows/MainWindowKeyMapping.cs
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindowKeyMapping.cs
@@ -169,6 +169,10 @@ namespace FalconBMS.Launcher.Windows
         /// <param name="e"></param>
         internal void MainWindowKeyMapping_HandleTimerTick()
         {
+            // Don't burn CPU displaying input events, if our window is inactive.
+            Window activeWin = Program.activeWin;
+            if (!activeWin.IsActive) return;
+
             try
             {
                 directInputDevice.GetCurrentKeyboardState();


### PR DESCRIPTION
- Version 2.4.1.10
- Prototype new 'Falcon BMS VR.cfg' feature -- injects overrides into 'Falcon BMS User.cfg' when selecting either VR or XR.
- Fixup cfg file entries (cleanup whitespace, convert unicode-doublequotes).
- Fix for VR users - don't emit g_nVRHMD cfg, it's redundant with -vr / -xr cmd line args.
- Fix for vJoy users (FoxVox et al) - don't ignore joystick button presses while window is inactive.
