### PR TITLE
Post-U4.1 fixes

### DIFF
--- a/Falcon BMS Alternative Launcher/Input/ButtonStateTracker.cs
+++ b/Falcon BMS Alternative Launcher/Input/ButtonStateTracker.cs
@@ -34,7 +34,7 @@ namespace FalconBMS.Launcher.Input
         {
             // Init button buffer with current button-states -- this is important for "stateful" knobs, dials and switches, where 
             // one of a group of buttons is always in a signalled (on) state.
-            if (true)
+            try
             {
                 byte[] buttonState = _hwDevice.CurrentJoystickState.GetButtons();
 
@@ -43,9 +43,16 @@ namespace FalconBMS.Launcher.Input
                 if (buttonState.Length < _lastButtons.Length)
                     Array.Clear(_lastButtons, buttonState.Length, (_lastButtons.Length - buttonState.Length));
             }
+            catch (Exception ex)
+            {
+                // Microsoft.DirectX.DirectInput.InputLostException happens on some systems - reasons unclear.
+                Diagnostics.Log(ex);
+
+                Array.Clear(_lastButtons, 0, _lastButtons.Length);
+            }
 
             // Init povhat buffer, in same way.
-            if (true)
+            try
             {
                 //NB: the values returned by DirectInput are in compass-direction x100. (eg. "right" == 9_000)
                 int[] povhatState = _hwDevice.CurrentJoystickState.GetPointOfView();
@@ -55,6 +62,13 @@ namespace FalconBMS.Launcher.Input
                 if (povhatState.Length < _lastPovHats.Length)
                     Array.Clear(_lastPovHats, povhatState.Length, (_lastPovHats.Length - povhatState.Length));
             }
+            catch (Exception ex)
+            {
+                // Microsoft.DirectX.DirectInput.InputLostException happens on some systems - reasons unclear.
+                Diagnostics.Log(ex);
+
+                Array.Clear(_lastPovHats, 0, _lastPovHats.Length);
+            }
 
             return;
         }
@@ -62,7 +76,7 @@ namespace FalconBMS.Launcher.Input
         public void PollUpdate()
         {
             // Poll and scan button states.
-            if (true)
+            try
             {
                 byte[] buttonState = _hwDevice.CurrentJoystickState.GetButtons();
 
@@ -80,9 +94,14 @@ namespace FalconBMS.Launcher.Input
                     }
                 }
             }
+            catch (Exception ex)
+            {
+                // Microsoft.DirectX.DirectInput.InputLostException happens on some systems - reasons unclear.
+                Diagnostics.Log(ex);
+            }
 
             // Poll and scan povhat states.
-            if (true)
+            try
             {
                 int[] povhatState = _hwDevice.CurrentJoystickState.GetPointOfView();
 
@@ -100,6 +119,11 @@ namespace FalconBMS.Launcher.Input
                         _lastPovHats[i] = iCurr;
                     }
                 }
+            }
+            catch (Exception ex)
+            {
+                // Microsoft.DirectX.DirectInput.InputLostException happens on some systems - reasons unclear.
+                Diagnostics.Log(ex);
             }
 
             return;

--- a/Falcon BMS Alternative Launcher/Input/DeviceControl.cs
+++ b/Falcon BMS Alternative Launcher/Input/DeviceControl.cs
@@ -48,7 +48,12 @@ namespace FalconBMS.Launcher.Input
             {
                 if (suppressList.IsDeviceSuppressed(dev.InstanceGuid) ||
                     suppressList.IsDeviceSuppressed(dev.ProductGuid))
+                {
+                    Diagnostics.Log($"Ignoring suppressed device: pidvid {dev.ProductGuid} instance {dev.InstanceGuid}", Diagnostics.LogLevels.Info);
                     continue;
+                }
+
+                Diagnostics.Log($"Found device: pidvid {dev.ProductGuid} instance {dev.InstanceGuid}", Diagnostics.LogLevels.Info);
 
                 Device hwdev = new Device(dev.InstanceGuid);
                 JoyAssgn joy = new JoyAssgn(hwdev);

--- a/Falcon BMS Alternative Launcher/Input/DeviceControl.cs
+++ b/Falcon BMS Alternative Launcher/Input/DeviceControl.cs
@@ -49,11 +49,11 @@ namespace FalconBMS.Launcher.Input
                 if (suppressList.IsDeviceSuppressed(dev.InstanceGuid) ||
                     suppressList.IsDeviceSuppressed(dev.ProductGuid))
                 {
-                    Diagnostics.Log($"Ignoring suppressed device: pidvid {dev.ProductGuid} instance {dev.InstanceGuid}", Diagnostics.LogLevels.Info);
+                    Diagnostics.Log($"Ignoring suppressed device: pidvid {dev.ProductGuid}; instance {dev.InstanceGuid}", Diagnostics.LogLevels.Info);
                     continue;
                 }
 
-                Diagnostics.Log($"Found device: pidvid {dev.ProductGuid} instance {dev.InstanceGuid}", Diagnostics.LogLevels.Info);
+                Diagnostics.Log($"Found device: {dev.ProductName}; pidvid {dev.ProductGuid}; instance {dev.InstanceGuid}", Diagnostics.LogLevels.Info);
 
                 Device hwdev = new Device(dev.InstanceGuid);
                 JoyAssgn joy = new JoyAssgn(hwdev);

--- a/Falcon BMS Alternative Launcher/Input/JoyAssgn.cs
+++ b/Falcon BMS Alternative Launcher/Input/JoyAssgn.cs
@@ -194,9 +194,9 @@ namespace FalconBMS.Launcher.Input
                 }
                 return input;
             }
-            catch
+            catch (Exception ex)
             {
-                Diagnostics.Log("JoyAssgn: catching exception from hwDevice.CurrentJoystickState.");
+                Diagnostics.Log(ex);
                 return 0;
             }
         }
@@ -527,8 +527,10 @@ namespace FalconBMS.Launcher.Input
             {
                 return hwDevice.CurrentJoystickState;
             }
-            catch 
+            catch (Exception ex)
             {
+                Diagnostics.Log(ex);
+
                 return new JoystickState();
             }
         }
@@ -544,9 +546,12 @@ namespace FalconBMS.Launcher.Input
                 Array.Copy(buttonStates, buttonStates128, Math.Min(buttonStates.Length, buttonStates128.Length));
                 return buttonStates128;
             }
-            catch 
+            catch (Exception ex)
             {
-                return new byte[128];
+                // Microsoft.DirectX.DirectInput.InputLostException happens on some systems - reasons unclear.
+                Diagnostics.Log(ex);
+
+                return new byte[CommonConstants.DX_MAX_BUTTONS];
             }
         }
 
@@ -557,13 +562,16 @@ namespace FalconBMS.Launcher.Input
                 int[] hatStates = hwDevice.CurrentJoystickState.GetPointOfView();
                 if (hatStates.Length == CommonConstants.DX_MAX_HATS) return hatStates;
 
-                int[] hatStates8 = new int[CommonConstants.DX_MAX_HATS];
-                Array.Copy(hatStates, hatStates8, Math.Min(hatStates.Length, hatStates8.Length));
-                return hatStates8;
+                int[] hatStates4 = new int[CommonConstants.DX_MAX_HATS];
+                Array.Copy(hatStates, hatStates4, Math.Min(hatStates.Length, hatStates4.Length));
+                return hatStates4;
             }
-            catch
+            catch (Exception ex)
             {
-                return new int[8];
+                // Microsoft.DirectX.DirectInput.InputLostException happens on some systems - reasons unclear.
+                Diagnostics.Log(ex);
+
+                return new int[CommonConstants.DX_MAX_HATS];
             }
         }
 

--- a/Falcon BMS Alternative Launcher/Properties/AssemblyInfo.cs
+++ b/Falcon BMS Alternative Launcher/Properties/AssemblyInfo.cs
@@ -52,6 +52,6 @@ using System.Windows;
 [assembly: AssemblyVersion("2.4.1.9999")]
 [assembly: AssemblyFileVersion("2.4.1.9999")]
 #else
-[assembly: AssemblyVersion("2.4.1.13")]
-[assembly: AssemblyFileVersion("2.4.1.13")]
+[assembly: AssemblyVersion("2.4.1.14")]
+[assembly: AssemblyFileVersion("2.4.1.14")]
 #endif

--- a/Falcon BMS Alternative Launcher/Starter/Starter432.cs
+++ b/Falcon BMS Alternative Launcher/Starter/Starter432.cs
@@ -1,8 +1,5 @@
-﻿using System.IO;
-using System.ServiceModel.Syndication;
-using System.Windows;
-using System.Xml;
-using System.Xml.Linq;
+﻿using System;
+
 using FalconBMS.Launcher.Windows;
 
 namespace FalconBMS.Launcher.Starter
@@ -28,7 +25,7 @@ namespace FalconBMS.Launcher.Starter
             switch (((System.Windows.Controls.Button)sender).Name)
             {
                 case "Launch_UPD":
-                    process = System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Updater.exe");
+                    process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Updater.exe");
                     mainWindow.Close();
                     break;
                 case "Launch_BMS_Large":
@@ -37,29 +34,32 @@ namespace FalconBMS.Launcher.Starter
                     // OVERRIDE SETTINGS.
                     mainWindow.executeOverride();
 
-                    string appPlatform = appReg.GetInstallDir() + "/Bin/x86/Falcon BMS.exe";
-                    process = System.Diagnostics.Process.Start(appPlatform, strCmdText);
+                    string bmsExe = appReg.GetInstallDir() + "/Bin/x86/Falcon BMS.exe";
+                    process = Utils.LaunchProcess(bmsExe, strCmdText);
                     MainWindow.bmsHasBeenLaunched = true;
                     mainWindow.Close();
                     break;
                 case "Launch_CFG":
-                    process = System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Config.exe");
+                    process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Config.exe");
                     mainWindow.minimizeWindowUntilProcessEnds(process);
                     break;
                 case "Launch_DISX":
-                    System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Bin/x86/Display Extraction.exe");
+                    Utils.LaunchProcess(appReg.GetInstallDir() + "/Bin/x86/Display Extraction.exe");
                     break;
                 case "Launch_IVCC":
-                    Directory.SetCurrentDirectory(appReg.GetInstallDir() + "/Bin/x86/IVC/");
-                    System.Diagnostics.Process.Start("IVC Client.exe");
+                    string ivcClientCmd = appReg.GetInstallDir() + "/Bin/x86/IVC/IVC Client.exe";
+                    string ivcClientCwd = appReg.GetInstallDir() + "/Bin/x86/IVC";
+                    Utils.LaunchProcess(ivcClientCmd, args:null, ivcClientCwd);
                     break;
                 case "Launch_IVCS":
-                    System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Bin/x86/IVC/IVC Server.exe");
+                    string ivcServerCmd = appReg.GetInstallDir() + "/Bin/x86/IVC/IVC Server.exe";
+                    string ivcServerCwd = appReg.GetInstallDir() + "/Bin/x86/IVC";
+                    Utils.LaunchProcess(ivcServerCmd, args:null, ivcServerCwd);
                     break;
                 case "Launch_AVC":
                     break;
                 case "Launch_EDIT":
-                    System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Bin/x64/Editor.exe");
+                    Utils.LaunchProcess(appReg.GetInstallDir() + "/Bin/x64/Editor.exe");
                     break;
             }
         }

--- a/Falcon BMS Alternative Launcher/Starter/Starter433.cs
+++ b/Falcon BMS Alternative Launcher/Starter/Starter433.cs
@@ -28,7 +28,7 @@ namespace FalconBMS.Launcher.Starter
             switch (((System.Windows.Controls.Button)sender).Name)
             {
                 case "Launch_UPD":
-                    process = System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Updater.exe");
+                    process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Updater.exe");
                     mainWindow.Close();
                     break;
                 case "Launch_BMS_Large":
@@ -37,35 +37,35 @@ namespace FalconBMS.Launcher.Starter
                     // OVERRIDE SETTINGS.
                     mainWindow.executeOverride();
 
-                    string appPlatform = appReg.GetInstallDir() + "/Bin/x64/Falcon BMS.exe";
-                    if (File.Exists(appPlatform) == false)
+                    string bmsExe = appReg.GetInstallDir() + "/Bin/x64/Falcon BMS.exe";
+                    if (File.Exists(bmsExe) == false)
                         return;
 
-                    process = System.Diagnostics.Process.Start(appPlatform, strCmdText);
+                    process = Utils.LaunchProcess(bmsExe, strCmdText);
                     MainWindow.bmsHasBeenLaunched = true;
                     mainWindow.Close();
                     break;
                 case "Launch_CFG":
-                    process = System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Config.exe");
+                    process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Config.exe");
                     mainWindow.minimizeWindowUntilProcessEnds(process);
                     break;
                 case "Launch_DISX":
-                    System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Bin/x86/Display Extraction.exe");
+                    Utils.LaunchProcess(appReg.GetInstallDir() + "/Bin/x86/Display Extraction.exe");
                     break;
                 case "Launch_IVCC":
-                    Directory.SetCurrentDirectory(appReg.GetInstallDir() + "/Bin/x86/IVC/");
-                    System.Diagnostics.Process.Start("IVC Client.exe");
+                    string ivcClientCmd = appReg.GetInstallDir() + "/Bin/x86/IVC/IVC Client.exe";
+                    string ivcClientCwd = appReg.GetInstallDir() + "/Bin/x86/IVC";
+                    Utils.LaunchProcess(ivcClientCmd, args: null, ivcClientCwd);
                     break;
                 case "Launch_IVCS":
-                    System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Bin/x86/IVC/IVC Server.exe");
+                    Utils.LaunchProcess(appReg.GetInstallDir() + "/Bin/x86/IVC/IVC Server.exe");
                     break;
                 case "Launch_AVC":
-                    Directory.SetCurrentDirectory(appReg.GetInstallDir() + "/Bin/x86/");
-                    process = System.Diagnostics.Process.Start("Avionics Configurator.exe");
+                    process = Utils.LaunchProcess("Avionics Configurator.exe", args:null, cwd: appReg.GetInstallDir() + "/Bin/x86/");
                     mainWindow.minimizeWindowUntilProcessEnds(process);
                     break;
                 case "Launch_EDIT":
-                    System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Bin/x86/Editor.exe");
+                    Utils.LaunchProcess(appReg.GetInstallDir() + "/Bin/x86/Editor.exe");
                     break;
             }
         }

--- a/Falcon BMS Alternative Launcher/Starter/Starter434.cs
+++ b/Falcon BMS Alternative Launcher/Starter/Starter434.cs
@@ -28,7 +28,7 @@ namespace FalconBMS.Launcher.Starter
             switch (((System.Windows.Controls.Button)sender).Name)
             {
                 case "Launch_UPD":
-                    process = System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Updater.exe");
+                    process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Updater.exe");
                     mainWindow.Close();
                     break;
                 case "Launch_BMS_Large":
@@ -37,32 +37,32 @@ namespace FalconBMS.Launcher.Starter
                     // OVERRIDE SETTINGS.
                     mainWindow.executeOverride();
 
-                    string appPlatform = appReg.GetInstallDir() + "/Bin/x64/Falcon BMS.exe";
-                    process = System.Diagnostics.Process.Start(appPlatform, strCmdText);
+                    string bmsExe = appReg.GetInstallDir() + "/Bin/x64/Falcon BMS.exe";
+                    process = Utils.LaunchProcess(bmsExe, strCmdText);
                     MainWindow.bmsHasBeenLaunched = true;
                     mainWindow.Close();
                     break;
                 case "Launch_CFG":
-                    process = System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Config.exe");
+                    process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Config.exe");
                     mainWindow.minimizeWindowUntilProcessEnds(process);
                     break;
                 case "Launch_DISX":
-                    System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Bin/x86/Display Extraction.exe");
+                    Utils.LaunchProcess(appReg.GetInstallDir() + "/Bin/x86/Display Extraction.exe");
                     break;
                 case "Launch_IVCC":
-                    Directory.SetCurrentDirectory(appReg.GetInstallDir() + "/Bin/x64/IVC/");
-                    System.Diagnostics.Process.Start("IVC Client.exe");
+                    string ivcClientCmd = appReg.GetInstallDir() + "/Bin/x64/IVC/IVC Client.exe";
+                    string ivcClientCwd = appReg.GetInstallDir() + "/Bin/x64/IVC";
+                    Utils.LaunchProcess(ivcClientCmd, args: null, ivcClientCwd);
                     break;
                 case "Launch_IVCS":
-                    System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Bin/x64/IVC/IVC Server.exe");
+                    Utils.LaunchProcess(appReg.GetInstallDir() + "/Bin/x64/IVC/IVC Server.exe");
                     break;
                 case "Launch_AVC":
-                    Directory.SetCurrentDirectory(appReg.GetInstallDir() + "/Bin/x86/");
-                    process = System.Diagnostics.Process.Start("Avionics Configurator.exe");
+                    process = Utils.LaunchProcess("Avionics Configurator.exe", args:null, cwd: appReg.GetInstallDir() + "/Bin/x86/");
                     mainWindow.minimizeWindowUntilProcessEnds(process);
                     break;
                 case "Launch_EDIT":
-                    System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Bin/x64/Editor.exe");
+                    Utils.LaunchProcess(appReg.GetInstallDir() + "/Bin/x64/Editor.exe");
                     break;
             }
         }

--- a/Falcon BMS Alternative Launcher/Starter/Starter435.cs
+++ b/Falcon BMS Alternative Launcher/Starter/Starter435.cs
@@ -28,7 +28,7 @@ namespace FalconBMS.Launcher.Starter
             switch (((System.Windows.Controls.Button)sender).Name)
             {
                 case "Launch_UPD":
-                    process = System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Updater.exe");
+                    process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Updater.exe");
                     mainWindow.Close();
                     break;
                 case "Launch_BMS_Large":
@@ -40,43 +40,41 @@ namespace FalconBMS.Launcher.Starter
                     string testPlatform = appReg.GetInstallDir() + "/Bin/x64/Falcon BMS Test.exe";
                     if (File.Exists(testPlatform) && MessageBox.Show(Program.mainWin, "Start Test Exe?", "Launcher", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
                     {
-                        process = System.Diagnostics.Process.Start(testPlatform, strCmdText);
+                        process = Utils.LaunchProcess(testPlatform, strCmdText);
                         MainWindow.bmsHasBeenLaunched = true;
                     }
                     else
                     {
-                        string appPlatform = appReg.GetInstallDir() + "/Bin/x64/Falcon BMS.exe";
-                        process = System.Diagnostics.Process.Start(appPlatform, strCmdText);
+                        string bmsExe = appReg.GetInstallDir() + "/Bin/x64/Falcon BMS.exe";
+                        process = Utils.LaunchProcess(bmsExe, strCmdText);
                         MainWindow.bmsHasBeenLaunched = true;
                     }
                     mainWindow.Close();
                     break;
                 case "Launch_CFG":
-                    process = System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Config.exe");
+                    process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Config.exe");
                     mainWindow.minimizeWindowUntilProcessEnds(process);
                     break;
                 case "Launch_RTTC":
-                    Directory.SetCurrentDirectory(appReg.GetInstallDir() + "/Tools/RTTRemote/");
-                    System.Diagnostics.Process.Start("RTTClient64.exe");
+                    Utils.LaunchProcess("RTTClient64.exe", args: null, cwd: appReg.GetInstallDir() + "/Tools/RTTRemote/");
                     break;
                 case "Launch_RTTS":
-                    Directory.SetCurrentDirectory(appReg.GetInstallDir() + "/Tools/RTTRemote/");
-                    System.Diagnostics.Process.Start("RTTServer64.exe");
+                    Utils.LaunchProcess("RTTServer64.exe", args: null, cwd: appReg.GetInstallDir() + "/Tools/RTTRemote/");
                     break;
                 case "Launch_IVCC":
-                    Directory.SetCurrentDirectory(appReg.GetInstallDir() + "/Bin/x64/IVC/");
-                    System.Diagnostics.Process.Start("IVC Client.exe");
+                    string ivcClientCmd = appReg.GetInstallDir() + "/Bin/x64/IVC/IVC Client.exe";
+                    string ivcClientCwd = appReg.GetInstallDir() + "/Bin/x64/IVC";
+                    Utils.LaunchProcess(ivcClientCmd, args: null, ivcClientCwd);
                     break;
                 case "Launch_IVCS":
-                    System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Bin/x64/IVC/IVC Server.exe");
+                    Utils.LaunchProcess(appReg.GetInstallDir() + "/Bin/x64/IVC/IVC Server.exe");
                     break;
                 case "Launch_AVC":
-                    Directory.SetCurrentDirectory(appReg.GetInstallDir() + "/Bin/x86/");
-                    process = System.Diagnostics.Process.Start("Avionics Configurator.exe");
+                    process = Utils.LaunchProcess("Avionics Configurator.exe", args: null, cwd: appReg.GetInstallDir() + "/Bin/x86/");
                     mainWindow.minimizeWindowUntilProcessEnds(process);
                     break;
                 case "Launch_EDIT":
-                    System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Bin/x64/Editor.exe");
+                    Utils.LaunchProcess(appReg.GetInstallDir() + "/Bin/x64/Editor.exe");
                     break;
             }
         }

--- a/Falcon BMS Alternative Launcher/Starter/Starter436I.cs
+++ b/Falcon BMS Alternative Launcher/Starter/Starter436I.cs
@@ -28,7 +28,7 @@ namespace FalconBMS.Launcher.Starter
             switch (((System.Windows.Controls.Button)sender).Name)
             {
                 case "Launch_UPD":
-                    process = System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Updater.exe");
+                    process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Updater.exe");
                     mainWindow.Close();
                     break;
                 case "Launch_BMS_Large":
@@ -37,37 +37,35 @@ namespace FalconBMS.Launcher.Starter
                     // OVERRIDE SETTINGS.
                     mainWindow.executeOverride();
 
-                    string appPlatform = appReg.GetInstallDir() + "/Bin/x86//Hub.exe";
-                    process = System.Diagnostics.Process.Start(appPlatform, strCmdText);
+                    string bmsExe = appReg.GetInstallDir() + "/Bin/x64/Falcon BMS.exe";
+                    process = Utils.LaunchProcess(bmsExe, strCmdText);
                     MainWindow.bmsHasBeenLaunched = true;
                     mainWindow.Close();
                     break;
                 case "Launch_CFG":
-                    process = System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Config.exe");
+                    process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Config.exe");
                     mainWindow.minimizeWindowUntilProcessEnds(process);
                     break;
                 case "Launch_RTTC":
-                    Directory.SetCurrentDirectory(appReg.GetInstallDir() + "/Tools/RTTRemote/");
-                    System.Diagnostics.Process.Start("RTTClient64.exe");
+                    Utils.LaunchProcess("RTTClient64.exe", args: null, cwd: appReg.GetInstallDir() + "/Tools/RTTRemote/");
                     break;
                 case "Launch_RTTS":
-                    Directory.SetCurrentDirectory(appReg.GetInstallDir() + "/Tools/RTTRemote/");
-                    System.Diagnostics.Process.Start("RTTServer64.exe");
+                    Utils.LaunchProcess("RTTServer64.exe", args: null, cwd: appReg.GetInstallDir() + "/Tools/RTTRemote/");
                     break;
                 case "Launch_IVCC":
-                    Directory.SetCurrentDirectory(appReg.GetInstallDir() + "/Bin/x64/IVC/");
-                    System.Diagnostics.Process.Start("IVC Client.exe");
+                    string ivcClientCmd = appReg.GetInstallDir() + "/Bin/x64/IVC/IVC Client.exe";
+                    string ivcClientCwd = appReg.GetInstallDir() + "/Bin/x64/IVC";
+                    Utils.LaunchProcess(ivcClientCmd, args: null, ivcClientCwd);
                     break;
                 case "Launch_IVCS":
-                    System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Bin/x64/IVC/IVC Server.exe");
+                    Utils.LaunchProcess(appReg.GetInstallDir() + "/Bin/x64/IVC/IVC Server.exe");
                     break;
                 case "Launch_AVC":
-                    Directory.SetCurrentDirectory(appReg.GetInstallDir() + "/Bin/x86/");
-                    process = System.Diagnostics.Process.Start("Avionics Configurator.exe");
+                    process = Utils.LaunchProcess("Avionics Configurator.exe", args: null, cwd: appReg.GetInstallDir() + "/Bin/x86/");
                     mainWindow.minimizeWindowUntilProcessEnds(process);
                     break;
                 case "Launch_EDIT":
-                    System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Bin/x64/Editor.exe");
+                    Utils.LaunchProcess(appReg.GetInstallDir() + "/Bin/x64/Editor.exe");
                     break;
             }
         }

--- a/Falcon BMS Alternative Launcher/SteamVR.cs
+++ b/Falcon BMS Alternative Launcher/SteamVR.cs
@@ -110,7 +110,7 @@ namespace FalconBMS.Launcher
         {
             if (File.Exists(installPath))
             {
-                process = Process.Start(installPath);
+                process = Utils.LaunchProcess(installPath);
             }
         }
         public void Stop()

--- a/Falcon BMS Alternative Launcher/Utils.cs
+++ b/Falcon BMS Alternative Launcher/Utils.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
-using System.Collections.Generic;
-using System.Linq;
+using System.Diagnostics;
 using System.Text;
 
 namespace FalconBMS.Launcher
@@ -14,6 +13,25 @@ namespace FalconBMS.Launcher
         {
             UTF8Encoding utf8enc = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
             return new StreamWriter(pathname, append, utf8enc);
+        }
+
+        public static Process LaunchProcess(string exe, string args=null, string cwd=null)
+        {
+            Diagnostics.Log($"Launching EXE: {exe} {args}", Diagnostics.LogLevels.Info);
+            ProcessStartInfo psi = new ProcessStartInfo(exe, args);
+            psi.UseShellExecute = false;
+            psi.WorkingDirectory = cwd;
+
+            return Process.Start(psi);
+        }
+
+        public static Process LaunchAppOrBrowserUrl(string url)
+        {
+            Diagnostics.Log($"Launching URL: {url}", Diagnostics.LogLevels.Info);
+            ProcessStartInfo psi = new ProcessStartInfo(url);
+            psi.UseShellExecute = true;
+
+            return Process.Start(psi);
         }
     }
 }

--- a/Falcon BMS Alternative Launcher/Windows/CallsignWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/CallsignWindow.xaml.cs
@@ -1,16 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
 using System.Text.RegularExpressions;
 
 using FalconBMS.Launcher.Input;
@@ -124,18 +115,7 @@ namespace FalconBMS.Launcher.Windows
                 return;
             }
 
-            string command = $"-o {lbkPathDQ} write-default --name {pilotNameDQ} --callsign {pilotCallsignDQ}";
-            //string command = 
-            //    "-o \"" 
-            //    + appReg.GetInstallDir() 
-            //    + CommonConstants.CONFIGFOLDERBACKSLASH 
-            //    + TextBox_Callsign.Text 
-            //    + ".lbk\" write-default --name \"" 
-            //    + TextBox_PilotName.Text 
-            //    + "\" --callsign \"" 
-            //    + TextBox_Callsign.Text 
-            //    + "\"";
-            Diagnostics.Log(command);
+            string logcatArgs = $"-o {lbkPathDQ} write-default --name {pilotNameDQ} --callsign {pilotCallsignDQ}";
 
             string thisExeDirectory = System.IO.Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
             string logcatExePath = System.IO.Path.Combine(thisExeDirectory, CommonConstants.LOGCAT);
@@ -147,7 +127,7 @@ namespace FalconBMS.Launcher.Windows
                 return;
             }
 
-            Process logcatExe = Process.Start(CommonConstants.LOGCAT, command);
+            Process logcatExe = Utils.LaunchProcess(CommonConstants.LOGCAT, logcatArgs);
             logcatExe.WaitForExit();
 
             if (logcatExe.ExitCode != 0)

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
@@ -440,7 +440,7 @@ namespace FalconBMS.Launcher.Windows
         {
             try
             {
-                System.Diagnostics.Process.Start(appReg.theaterOwnConfig);
+                Utils.LaunchProcess(appReg.theaterOwnConfig);
             }
             catch (Exception ex)
             {
@@ -478,7 +478,7 @@ namespace FalconBMS.Launcher.Windows
         {
             try
             {
-                System.Diagnostics.Process.Start(appReg.GetInstallDir() + "/Docs");
+                Utils.LaunchAppOrBrowserUrl(appReg.GetInstallDir() + "/Docs");
             }
             catch (Exception ex)
             {
@@ -600,11 +600,11 @@ namespace FalconBMS.Launcher.Windows
                                 Properties.Settings.Default.Third_WDP = fbd.SelectedPath;
                             else
                             {
-                                System.Diagnostics.Process.Start(downloadlink);
+                                Utils.LaunchAppOrBrowserUrl(downloadlink);
                                 return;
                             }
                         }
-                        System.Diagnostics.Process.Start(installexe);
+                        Utils.LaunchProcess(installexe);
                         break;
                     case "Launch_MC":
                         target = "\\Mission Commander.exe";
@@ -624,11 +624,11 @@ namespace FalconBMS.Launcher.Windows
                                 Properties.Settings.Default.Third_MC = fbd.SelectedPath;
                             else
                             {
-                                System.Diagnostics.Process.Start(downloadlink);
+                                Utils.LaunchAppOrBrowserUrl(downloadlink);
                                 return;
                             }
                         }
-                        System.Diagnostics.Process.Start(installexe);
+                        Utils.LaunchProcess(installexe);
                         break;
                     case "Launch_WC":
                         target = "\\Weather Commander.exe";
@@ -648,11 +648,11 @@ namespace FalconBMS.Launcher.Windows
                                 Properties.Settings.Default.Third_WC = fbd.SelectedPath;
                             else
                             {
-                                System.Diagnostics.Process.Start(downloadlink);
+                                Utils.LaunchAppOrBrowserUrl(downloadlink);
                                 return;
                             }
                         }
-                        System.Diagnostics.Process.Start(installexe);
+                        Utils.LaunchProcess(installexe);
                         break;
                     case "Launch_F4WX":
                         target = "\\F4Wx.exe";
@@ -674,11 +674,11 @@ namespace FalconBMS.Launcher.Windows
                                 Properties.Settings.Default.Third_F4WX = fbd.SelectedPath;
                             else
                             {
-                                System.Diagnostics.Process.Start(downloadlink);
+                                Utils.LaunchAppOrBrowserUrl(downloadlink);
                                 return;
                             }
                         }
-                        System.Diagnostics.Process.Start(installexe);
+                        Utils.LaunchProcess(installexe);
                         break;
                     case "Launch_F4RADAR":
                         downloadlink = "https://forum.falcon-bms.com/topic/18356/f4radar-lightweight-standalone-radar-application";
@@ -699,11 +699,11 @@ namespace FalconBMS.Launcher.Windows
                                 Properties.Settings.Default.Third_F4WX = fbd.SelectedPath;
                             else
                             {
-                                System.Diagnostics.Process.Start(downloadlink);
+                                Utils.LaunchAppOrBrowserUrl(downloadlink);
                                 return;
                             }
                         }
-                        System.Diagnostics.Process.Start(installexe);
+                        Utils.LaunchProcess(installexe);
                         break;
                 }
             }
@@ -806,7 +806,7 @@ namespace FalconBMS.Launcher.Windows
         {
             try
             {
-                System.Diagnostics.Process.Start("http://www.weapondeliveryplanner.nl/");
+                Utils.LaunchAppOrBrowserUrl("http://www.weapondeliveryplanner.nl/");
             }
             catch (Exception ex)
             {
@@ -818,7 +818,7 @@ namespace FalconBMS.Launcher.Windows
         {
             try
             {
-                System.Diagnostics.Process.Start("https://apps.dtic.mil/docs/citations/ADA414893");
+                Utils.LaunchAppOrBrowserUrl("https://apps.dtic.mil/docs/citations/ADA414893");
             }
             catch (Exception ex)
             {

--- a/Falcon BMS Alternative Launcher/Windows/RSSReader.cs
+++ b/Falcon BMS Alternative Launcher/Windows/RSSReader.cs
@@ -128,12 +128,12 @@ namespace FalconBMS.Launcher.Windows
 
             private void Try_RequestNavigate(object sender, RequestNavigateEventArgs e)
             {
-                System.Diagnostics.Process.Start(link);
+                Utils.LaunchAppOrBrowserUrl(link);
             }
 
             private void Try_RequestNavigateTop(object sender, RequestNavigateEventArgs e)
             {
-                System.Diagnostics.Process.Start(webSite);
+                Utils.LaunchAppOrBrowserUrl(webSite);
             }
 
             int IComparable<Article>.CompareTo(Article other)


### PR DESCRIPTION
- Fix periodic freezes/lockups on some systems - replace hacky device-scan timer with WM_DEVICECHANGE handler
- Fix KeyMappingDialog.ClearDX button breaks links with the button-trackers
- Improve diagnostic logging for DirectInput devices
- Handle (ignore) the DirectInput.InputLostException which happens when a device is unplugged.


