### PR TITLE
Add ExportRTT option to Launcher tab

### DIFF
--- a/Falcon BMS Alternative Launcher/App.config
+++ b/Falcon BMS Alternative Launcher/App.config
@@ -89,6 +89,9 @@
             <setting name="Misc_3DClickableCursorFixToCenter" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="Misc_bExportRTTTextures" serializeAs="String">
+                <value>False</value>
+            </setting>
         </FalconBMS.Launcher.Properties.Settings>
         <FalconBMS_Alternative_Launcher_Cs.Properties.Settings>
             <setting name="Platform" serializeAs="String">

--- a/Falcon BMS Alternative Launcher/App.config
+++ b/Falcon BMS Alternative Launcher/App.config
@@ -15,16 +15,16 @@
                 <value>False</value>
             </setting>
             <setting name="CMD_ACMI" serializeAs="String">
-                <value>True</value>
+                <value>False</value>
             </setting>
             <setting name="CMD_WINDOW" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="CMD_NOMOVIE" serializeAs="String">
                 <value>True</value>
             </setting>
-            <setting name="CMD_EF" serializeAs="String">
+            <setting name="CMD_NOMOVIE" serializeAs="String">
                 <value>False</value>
+            </setting>
+            <setting name="CMD_EF" serializeAs="String">
+                <value>True</value>
             </setting>
             <setting name="CMD_BW" serializeAs="String">
                 <value>1024</value>
@@ -60,7 +60,7 @@
                 <value>C:\</value>
             </setting>
             <setting name="CMD_MONO" serializeAs="String">
-                <value>True</value>
+                <value>False</value>
             </setting>
             <setting name="Misc_SmartScalingOverride" serializeAs="String">
                 <value>True</value>

--- a/Falcon BMS Alternative Launcher/AppProperties.cs
+++ b/Falcon BMS Alternative Launcher/AppProperties.cs
@@ -50,6 +50,18 @@ namespace FalconBMS.Launcher
                 mainWindow.VR_SteamVR.IsChecked = false;
                 mainWindow.VR_OpenXR.IsChecked = false;
             }
+
+            if (Properties.Settings.Default.Misc_bExportRTTTextures)
+            {
+                mainWindow.RTT_Enable.IsChecked = true;
+                mainWindow.RTT_Disable.IsChecked = false;
+            }
+            else
+            {
+                mainWindow.RTT_Disable.IsChecked = true;
+                mainWindow.RTT_Enable.IsChecked = false;
+            }
+
             mainWindow.CMD_BW.Content               = "BW : " + bandWidthDefault;
             mainWindow.AB_Throttle.Visibility       = Visibility.Hidden;
             mainWindow.AB_Throttle_Right.Visibility = Visibility.Hidden;
@@ -73,6 +85,7 @@ namespace FalconBMS.Launcher
             Properties.Settings.Default.Misc_NaturalHeadMovement  = (bool)mainWindow.Misc_NaturalHeadMovement.IsChecked;
             Properties.Settings.Default.Misc_PilotModel           = (bool)mainWindow.Misc_PilotModel.IsChecked;
             Properties.Settings.Default.VR_Option = (bool)mainWindow.VR_SteamVR.IsChecked ? "SteamVR" : (bool)mainWindow.VR_OpenXR.IsChecked ? "OpenXR" : "NoVR";
+            Properties.Settings.Default.Misc_bExportRTTTextures   = (mainWindow.RTT_Enable.IsChecked == true);
             Properties.Settings.Default.Save();
         }
 

--- a/Falcon BMS Alternative Launcher/Override/OverrideSetting.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSetting.cs
@@ -63,6 +63,7 @@ namespace FalconBMS.Launcher.Override
                 OverridePovDeviceIDs(cfgUser, inGameAxis);
 
                 ApplyVROverrides(cfgUser);
+                ApplyMiscOverrides(cfgUser);
             }
         }
 
@@ -167,6 +168,21 @@ namespace FalconBMS.Launcher.Override
                 }
             }
             return;
+        }
+        private static void WriteIfOverride(StreamWriter cfg, string key, int value, int defaultValue, string comment)
+        {
+            if (value != defaultValue)
+                cfg.WriteLine($"set {key} {value} {comment}");
+        }
+        protected virtual void ApplyMiscOverrides(StreamWriter cfg)
+        {
+            var intFlags = new (string key, int current, int def)[]
+            {
+                ("g_bExportRTTTextures", (mainWindow.RTT_Enable?.IsChecked == true) ? 1 : 0, 0),
+            };
+
+            foreach (var (key, current, def) in intFlags)
+                WriteIfOverride(cfg, key, current, def, CommonConstants.CFGOVERRIDECOMMENT);
         }
 
         protected void SaveDeviceSorting(DeviceControl deviceControl)

--- a/Falcon BMS Alternative Launcher/Properties/Settings.Designer.cs
+++ b/Falcon BMS Alternative Launcher/Properties/Settings.Designer.cs
@@ -37,7 +37,7 @@ namespace FalconBMS.Launcher.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool CMD_ACMI {
             get {
                 return ((bool)(this["CMD_ACMI"]));
@@ -49,7 +49,7 @@ namespace FalconBMS.Launcher.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool CMD_WINDOW {
             get {
                 return ((bool)(this["CMD_WINDOW"]));
@@ -61,7 +61,7 @@ namespace FalconBMS.Launcher.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool CMD_NOMOVIE {
             get {
                 return ((bool)(this["CMD_NOMOVIE"]));
@@ -73,7 +73,7 @@ namespace FalconBMS.Launcher.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool CMD_EF {
             get {
                 return ((bool)(this["CMD_EF"]));
@@ -217,7 +217,7 @@ namespace FalconBMS.Launcher.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool CMD_MONO {
             get {
                 return ((bool)(this["CMD_MONO"]));

--- a/Falcon BMS Alternative Launcher/Properties/Settings.Designer.cs
+++ b/Falcon BMS Alternative Launcher/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace FalconBMS.Launcher.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.6.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.14.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -332,6 +332,18 @@ namespace FalconBMS.Launcher.Properties {
             }
             set {
                 this["Misc_3DClickableCursorFixToCenter"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool Misc_bExportRTTTextures {
+            get {
+                return ((bool)(this["Misc_bExportRTTTextures"]));
+            }
+            set {
+                this["Misc_bExportRTTTextures"] = value;
             }
         }
     }

--- a/Falcon BMS Alternative Launcher/Properties/Settings.settings
+++ b/Falcon BMS Alternative Launcher/Properties/Settings.settings
@@ -6,16 +6,16 @@
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="CMD_ACMI" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
+      <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="CMD_WINDOW" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
-    </Setting>
-    <Setting Name="CMD_NOMOVIE" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
-    <Setting Name="CMD_EF" Type="System.Boolean" Scope="User">
+    <Setting Name="CMD_NOMOVIE" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="CMD_EF" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="CMD_BW" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">1024</Value>
@@ -51,7 +51,7 @@
       <Value Profile="(Default)">C:\</Value>
     </Setting>
     <Setting Name="CMD_MONO" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
+      <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="Misc_SmartScalingOverride" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>

--- a/Falcon BMS Alternative Launcher/Properties/Settings.settings
+++ b/Falcon BMS Alternative Launcher/Properties/Settings.settings
@@ -80,5 +80,8 @@
     <Setting Name="Misc_3DClickableCursorFixToCenter" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="Misc_bExportRTTTextures" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Falcon BMS Alternative Launcher/Starter/AbstractStarter.cs
+++ b/Falcon BMS Alternative Launcher/Starter/AbstractStarter.cs
@@ -25,15 +25,15 @@ namespace FalconBMS.Launcher.Starter
         public virtual string getCommandLine()
         {
             string strCmdText = "";
-            if (mainWindow.CMD_ACMI.IsChecked == false)
+            if (mainWindow.CMD_ACMI.IsChecked == true)
                 strCmdText += "-acmi ";
-            if (mainWindow.CMD_WINDOW.IsChecked == false)
+            if (mainWindow.CMD_WINDOW.IsChecked == true)
                 strCmdText += "-window ";
-            if (mainWindow.CMD_NOMOVIE.IsChecked == false)
+            if (mainWindow.CMD_NOMOVIE.IsChecked == true)
                 strCmdText += "-nomovie ";
-            if (mainWindow.CMD_EF.IsChecked == false)
+            if (mainWindow.CMD_EF.IsChecked == true)
                 strCmdText += "-ef ";
-            if (mainWindow.CMD_MONO.IsChecked == false)
+            if (mainWindow.CMD_MONO.IsChecked == true)
                 strCmdText += "-mono ";
 
             if (mainWindow.VR_SteamVR.IsVisible && mainWindow.VR_SteamVR.IsChecked == true)

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -265,9 +265,14 @@
                         <Label Content="Command Line :" HorizontalAlignment="Left" VerticalAlignment="Top" FontWeight="Bold" Margin="0,96,0,-27" />
 
                         <Label x:Name="Label_VR" Content="Virtual Reality:" HorizontalAlignment="Left" Margin="0,64,0,0" VerticalAlignment="Top" FontWeight="Bold" />
-                        <RadioButton x:Name="VR_NoVR" Content="No VR" HorizontalAlignment="Left" Margin="181,69,0,0" VerticalAlignment="Top"/>
-                        <RadioButton x:Name="VR_SteamVR" Content="SteamVR" HorizontalAlignment="Left" Margin="250,69,0,0" VerticalAlignment="Top" Click="Misc_VR_Click"/>
-                        <RadioButton x:Name="VR_OpenXR" Content="OpenXR" HorizontalAlignment="Left" Margin="329,69,0,0" VerticalAlignment="Top" RenderTransformOrigin="-7.082,0.583"/>
+                        <RadioButton x:Name="VR_NoVR" GroupName="VR" Content="No VR" HorizontalAlignment="Left" Margin="181,69,0,0" VerticalAlignment="Top"/>
+                        <RadioButton x:Name="VR_SteamVR" GroupName="VR" Content="SteamVR" HorizontalAlignment="Left" Margin="250,69,0,0" VerticalAlignment="Top" Click="Misc_VR_Click"/>
+                        <RadioButton x:Name="VR_OpenXR" GroupName="VR" Content="OpenXR" HorizontalAlignment="Left" Margin="329,69,0,0" VerticalAlignment="Top" RenderTransformOrigin="-7.082,0.583"/>
+
+                        <Label x:Name="Label_RTT" Content="Export RTT Textures:" HorizontalAlignment="Left" Margin="525,64,0,0" VerticalAlignment="Top" FontWeight="Bold"/>
+                        <RadioButton x:Name="RTT_Disable" GroupName="RTT" Content="Disable" HorizontalAlignment="Left" Margin="660,69,0,0" VerticalAlignment="Top"/>
+                        <RadioButton x:Name="RTT_Enable" GroupName="RTT" Content="Enable" HorizontalAlignment="Left" Margin="730,69,0,0" VerticalAlignment="Top"/>
+
                         <Label Content="Documentation and Manuals :" HorizontalAlignment="Left" Margin="0,32,0,0" VerticalAlignment="Top" FontWeight="Bold" />
                         <Button x:Name="OpenDocs" Content="Open Docs Folder" Style="{StaticResource AccentedSquareButtonStyle}" Controls:ControlsHelper.ContentCharacterCasing="Normal" HorizontalAlignment="Left" Margin="179,34,0,0" VerticalAlignment="Top" Width="141" Click="OpenDocs_Click" FontSize="10" Height="10"/>
 

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -276,12 +276,12 @@
                         <Label Content="Documentation and Manuals :" HorizontalAlignment="Left" Margin="0,32,0,0" VerticalAlignment="Top" FontWeight="Bold" />
                         <Button x:Name="OpenDocs" Content="Open Docs Folder" Style="{StaticResource AccentedSquareButtonStyle}" Controls:ControlsHelper.ContentCharacterCasing="Normal" HorizontalAlignment="Left" Margin="179,34,0,0" VerticalAlignment="Top" Width="141" Click="OpenDocs_Click" FontSize="10" Height="10"/>
 
-                        <ToggleButton x:Name="CMD_ACMI" Content="ACMI" HorizontalAlignment="Left" Margin="178,96,0,0" VerticalAlignment="Top" Width="64"/>
-                        <ToggleButton x:Name="CMD_WINDOW" Content="WINDOW" HorizontalAlignment="Left" Margin="260,96,0,0" VerticalAlignment="Top" Width="64" Click="CMD_WINDOW_Click"/>
-                        <ToggleButton x:Name="CMD_NOMOVIE" Content="NOMOVIE" HorizontalAlignment="Left" Margin="342,96,0,0" VerticalAlignment="Top" Width="64"/>
-                        <ToggleButton x:Name="CMD_EF" Content="EYEFLY" HorizontalAlignment="Left" Margin="425,96,0,0" VerticalAlignment="Top" Width="64"/>
-                        <ToggleButton x:Name="CMD_MONO" Content="DEBUG" HorizontalAlignment="Left" Margin="507,96,0,0" VerticalAlignment="Top" Width="64"/>
-                        <Button x:Name="CMD_BW" Content="BW : 1024" HorizontalAlignment="Left" Margin="591,96,0,0" VerticalAlignment="Top" Width="64" Click="CMD_BW_Click"/>
+                        <Controls:ToggleSwitch x:Name="CMD_ACMI" OnLabel="ACMI On" OffLabel="ACMI Off" HorizontalAlignment="Left" HorizontalContentAlignment="Left" FontSize="11" Margin="178,94,0,0" VerticalAlignment="Top" Width="120"/>
+                        <Controls:ToggleSwitch x:Name="CMD_WINDOW" OnLabel="WINDOW On" OffLabel="WINDOW Off" HorizontalAlignment="Left" HorizontalContentAlignment="Left" FontSize="11" Margin="313,94,0,0" VerticalAlignment="Top" Width="142" Click="CMD_WINDOW_Click"/>
+                        <Controls:ToggleSwitch x:Name="CMD_NOMOVIE" OnLabel="NOMOVIE On" OffLabel="NOMOVIE Off" HorizontalAlignment="Left" HorizontalContentAlignment="Left" FontSize="11" Margin="472,94,0,0" VerticalAlignment="Top" Width="144"/>
+                        <Controls:ToggleSwitch x:Name="CMD_EF" OnLabel="EYEFLY On" OffLabel="EYEFLY Off" HorizontalAlignment="Left" HorizontalContentAlignment="Left" FontSize="11" Margin="633,94,0,0" VerticalAlignment="Top" Width="128"/>
+                        <Controls:ToggleSwitch x:Name="CMD_MONO" OnLabel="DEBUG On" OffLabel="DEBUG Off" HorizontalAlignment="Left" HorizontalContentAlignment="Left" FontSize="11" Margin="776,94,0,0" VerticalAlignment="Top" Width="130"/>
+                        <Button x:Name="CMD_BW" Content="BW : 1024" HorizontalAlignment="Left" Margin="881,66,0,0" VerticalAlignment="Top" Width="64" Click="CMD_BW_Click"/>
                         <Controls:ToggleSwitch x:Name="AB_Test" Visibility="Hidden" OffLabel="A" OnLabel="B" Margin="700,10,10,10" HorizontalAlignment="Left" VerticalAlignment="Top" Width="85" Height="36" />
                     </Grid>
                     <ScrollViewer x:Name ="LogTextScroll" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Margin="48,57,563.667,349.333" Background="#54000000">


### PR DESCRIPTION
This PR adds radio buttons on the Launcher tab for enabling or disabling RTT Export.

- Mimics VR option for consistency.
- Adds 'g_bExportRTTTextures 1' to User.cfg only when enabled.
- Removes 'g_bExportRTTTextures' from User.cfg when disabled.
- Added a helper function _WriteIfOverride_ and an _ApplyMiscOverrides_ method to OverrideSettings.cs to allow for easier addition of more settings.

Tested on BMS 4.38i, 4.38, and 4.37. Verified that User.cfg updates correctly after pressing 'Launch'.