### PR TITLE
Gyroplatter/style cleanup

### DIFF
--- a/Falcon BMS Alternative Launcher/Falcon BMS Alternative Launcher.csproj
+++ b/Falcon BMS Alternative Launcher/Falcon BMS Alternative Launcher.csproj
@@ -165,6 +165,10 @@
     <Compile Include="TheaterList.cs" />
     <Compile Include="Input\DetentPosition.cs" />
     <Compile Include="Windows\RSSReader.cs" />
+    <Page Include="Styles\Styles.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Windows\AxisAssignWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/Falcon BMS Alternative Launcher/Styles/Styles.xaml
+++ b/Falcon BMS Alternative Launcher/Styles/Styles.xaml
@@ -1,0 +1,88 @@
+﻿<!-- Styles/Styles.xaml -->
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro">
+
+    <!-- LAUNCHER tab -->
+    <Style x:Key="LauncherHeading" TargetType="Label">
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="VerticalAlignment" Value="Top"/>
+        <Setter Property="FontSize" Value="24"/>
+        <Setter Property="FontWeight" Value="Bold"/>
+        <Setter Property="FontStyle" Value="Italic"/>
+        <Setter Property="Foreground" Value="#80FFFFFF" />
+    </Style>
+    <Style x:Key="LauncherTitle" TargetType="Label">
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="VerticalAlignment" Value="Top" />
+        <Setter Property="FontWeight" Value="Bold" />
+        <Setter Property="Foreground" Value="#80FFFFFF" />
+    </Style>
+    <Style x:Key="LauncherToggleSwitch"
+           TargetType="Controls:ToggleSwitch"
+           BasedOn="{StaticResource {x:Type Controls:ToggleSwitch}}">
+        <Setter Property="FontSize" Value="11"/>
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+        <Setter Property="VerticalAlignment" Value="Top"/>
+        <Setter Property="Foreground" Value="#80FFFFFF" />
+    </Style>
+    <Style x:Key="LauncherRadioButton" 
+           TargetType="RadioButton"
+           BasedOn="{StaticResource {x:Type RadioButton}}">
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="VerticalAlignment" Value="Top"/>
+    </Style>
+
+    <!-- AXISASSIGN tab -->
+    <Style x:Key="AxisHeading" TargetType="Label"
+            BasedOn="{StaticResource {x:Type Label}}">
+        <Setter Property="FontSize" Value="16"/>
+        <Setter Property="FontWeight" Value="Bold"/>
+        <Setter Property="FontStyle" Value="Oblique"/>
+        <Setter Property="Foreground" Value="#80FFFFFF"/>
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="VerticalAlignment" Value="Top"/>
+        <Setter Property="Height" Value="41"/>
+        <Setter Property="Width" Value="349"/>
+    </Style>
+    <Style x:Key="AxisTitle" TargetType="Label"
+           BasedOn="{StaticResource {x:Type Label}}">
+        <Setter Property="FontSize" Value="16"/>
+        <Setter Property="FontWeight" Value="Bold"/>
+        <Setter Property="Foreground" Value="#80FFFFFF"/>
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="VerticalAlignment" Value="Top"/>
+        <Setter Property="Height" Value="34"/>
+        <Setter Property="Width" Value="150"/>
+    </Style>
+    <Style x:Key="AssignButtonBase"
+       TargetType="Button"
+       BasedOn="{StaticResource {x:Type Button}}">
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="VerticalAlignment" Value="Top"/>
+        <Setter Property="Width" Value="74"/>
+        <Setter Property="Height" Value="27"/>
+        <Setter Property="MinWidth" Value="0"/>
+        <Setter Property="MinHeight" Value="0"/>
+        <Setter Property="Padding" Value="4,2"/>
+        <Setter Property="Background" Value="#FFFFFFFF"/>
+        <Setter Property="BorderBrush" Value="{x:Null}"/>
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Content" Value="Assign"/>
+    </Style>
+    <Style x:Key="AxisBar"
+       TargetType="Controls:MetroProgressBar"
+       BasedOn="{StaticResource {x:Type Controls:MetroProgressBar}}">
+        <Setter Property="Width" Value="256"/>
+        <Setter Property="Height" Value="10"/>
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="VerticalAlignment" Value="Top"/>
+        <Setter Property="Background" Value="#80202020"/>
+        <Setter Property="Foreground" Value="#803878A8"/>
+        <Setter Property="BorderBrush" Value="#80FFFFFF"/>
+        <Setter Property="BorderThickness" Value="1"/>
+    </Style>
+
+
+</ResourceDictionary>

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -119,78 +119,100 @@
                             </LinearGradientBrush>
                         </Border.Background>
                         <Grid HorizontalAlignment="Stretch" Height="auto" Margin="0,0,0,0" VerticalAlignment="Stretch" Width="auto">
-                            <Button x:Name="Launch_UPD" BorderThickness="10" BorderBrush="Black" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="20,0,0,33.333" Height="32" Width="32" Click="Launch_Click" MouseEnter="MouseEnterLauncher" MouseLeave="MouseLeaveLauncher">
+                            <Grid.Resources>
+                                <Style TargetType="Button">
+                                    <Setter Property="BorderThickness" Value="10" />
+                                    <Setter Property="BorderBrush" Value="Black" />
+                                    <Setter Property="HorizontalAlignment" Value="Left" />
+                                    <Setter Property="VerticalAlignment" Value="Bottom" />
+                                    <Setter Property="Width" Value="32" />
+                                    <Setter Property="Height" Value="32" />
+                                    <EventSetter Event="Click" Handler="Launch_Click"/>
+                                    <EventSetter Event="MouseEnter" Handler="MouseEnterLauncher"/>
+                                    <EventSetter Event="MouseLeave" Handler="MouseLeaveLauncher"/>
+                                </Style>
+                                <Style TargetType="Label">
+                                    <Setter Property="HorizontalAlignment" Value="Left" />
+                                    <Setter Property="VerticalAlignment" Value="Bottom" />
+                                    <Setter Property="Foreground" Value="#FFF0F0F0" />
+                                    <Setter Property="HorizontalContentAlignment" Value="Center" />
+                                    <Setter Property="FontWeight" Value="Bold" />
+                                    <Setter Property="FontSize" Value="8" />
+                                </Style>
+                            </Grid.Resources>
+
+                            <Button x:Name="Launch_UPD" Margin="20,0,0,33.333">
                                 <Button.Template>
                                     <ControlTemplate>
                                         <Image Source="/Resources/UPD.png"/>
                                     </ControlTemplate>
                                 </Button.Template>
                             </Button>
-                            <Button x:Name="Launch_CFG" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="90,0,0,33.333" Height="32" Width="32" Click="Launch_Click" MouseEnter="MouseEnterLauncher" MouseLeave="MouseLeaveLauncher">
+                            <Button x:Name="Launch_CFG" Margin="90,0,0,33.333">
                                 <Button.Template>
                                     <ControlTemplate>
                                         <Image Source="/Resources/CFG.png"/>
                                     </ControlTemplate>
                                 </Button.Template>
                             </Button>
-                            <Button x:Name="Launch_MMC" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="160,0,0,33.333" Height="32" Width="32" Click="Launch_Click" MouseEnter="MouseEnterLauncher" MouseLeave="MouseLeaveLauncher">
+                            <Button x:Name="Launch_MMC" Margin="160,0,0,33.333">
                                 <Button.Template>
                                     <ControlTemplate>
                                         <Image Source="/Resources/BmsMultiMon.png"/>
                                     </ControlTemplate>
                                 </Button.Template>
                             </Button>
-                            <Button x:Name="Launch_RTTC" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="230,0,0,33.333" Height="32" Width="32" Click="Launch_Click" MouseEnter="MouseEnterLauncher" MouseLeave="MouseLeaveLauncher">
+                            <Button x:Name="Launch_RTTC" Margin="230,0,0,33.333">
                                 <Button.Template>
                                     <ControlTemplate>
                                         <Image Source="/Resources/RTTClient64.png"/>
                                     </ControlTemplate>
                                 </Button.Template>
                             </Button>
-                            <Button x:Name="Launch_RTTS" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="300,0,0,33.333" Height="32" Width="32" Click="Launch_Click" MouseEnter="MouseEnterLauncher" MouseLeave="MouseLeaveLauncher">
+                            <Button x:Name="Launch_RTTS" Margin="300,0,0,33.333">
                                 <Button.Template>
                                     <ControlTemplate>
                                         <Image Source="/Resources/RTTServer64.png"/>
                                     </ControlTemplate>
                                 </Button.Template>
                             </Button>
-                            <Button x:Name="Launch_IVCC" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="370,0,0,33.333" Height="32" Width="32" Click="Launch_Click" MouseEnter="MouseEnterLauncher" MouseLeave="MouseLeaveLauncher">
+                            <Button x:Name="Launch_IVCC" Margin="370,0,0,33.333">
                                 <Button.Template>
                                     <ControlTemplate>
                                         <Image Source="/Resources/IVCC.png"/>
                                     </ControlTemplate>
                                 </Button.Template>
                             </Button>
-                            <Button x:Name="Launch_IVCS" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="440,0,0,33.333" Height="32" Width="32" Click="Launch_Click" MouseEnter="MouseEnterLauncher" MouseLeave="MouseLeaveLauncher">
+                            <Button x:Name="Launch_IVCS" Margin="440,0,0,33.333">
                                 <Button.Template>
                                     <ControlTemplate>
                                         <Image Source="/Resources/IVCS.png"/>
                                     </ControlTemplate>
                                 </Button.Template>
                             </Button>
-                            <Button x:Name="Launch_AVC" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="510,0,0,33.333" Height="32" Width="32" Click="Launch_Click" MouseEnter="MouseEnterLauncher" MouseLeave="MouseLeaveLauncher">
+                            <Button x:Name="Launch_AVC" Margin="510,0,0,33.333">
                                 <Button.Template>
                                     <ControlTemplate>
                                         <Image Source="/Resources/AVC.png"/>
                                     </ControlTemplate>
                                 </Button.Template>
                             </Button>
-                            <Button x:Name="Launch_EDIT" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="580,0,0,33.333" Height="32" Width="32"  Click="Launch_Click" MouseEnter="MouseEnterLauncher" MouseLeave="MouseLeaveLauncher">
+                            <Button x:Name="Launch_EDIT" Margin="580,0,0,33.333">
                                 <Button.Template>
                                     <ControlTemplate>
                                         <Image Source="/Resources/EDIT.png"/>
                                     </ControlTemplate>
                                 </Button.Template>
                             </Button>
-                            <Label x:Name="Label_UPD" Content="Update&#xD;&#xA;" HorizontalAlignment="Left" Margin="18,0,0,0" VerticalAlignment="Bottom" Foreground="#FFF0F0F0" HorizontalContentAlignment="Center" FontWeight="Bold" FontSize="8"/>
-                            <Label x:Name="Label_CFG" Content="Config&#xD;&#xA;" HorizontalAlignment="Left" Margin="88,0,0,0" VerticalAlignment="Bottom" Foreground="#FFF0F0F0" HorizontalContentAlignment="Center" FontWeight="Bold" FontSize="8"/>
-                            <Label x:Name="Label_MMC" Content="Display&#xD;&#xA;Config" HorizontalAlignment="Left" Margin="158,0,0,0" VerticalAlignment="Bottom" Foreground="#FFF0F0F0" HorizontalContentAlignment="Center" FontWeight="Bold" FontSize="8"/>
-                            <Label x:Name="Label_RTTC" Content="RTT Client&#xD;&#xA;" HorizontalAlignment="Left" Margin="220,0,0,0" VerticalAlignment="Bottom" Foreground="#FFF0F0F0" HorizontalContentAlignment="Center" FontWeight="Bold" FontSize="8"/>
-                            <Label x:Name="Label_RTTS" Content="RTT Server&#xD;&#xA;" HorizontalAlignment="Left" Margin="290,0,0,0" VerticalAlignment="Bottom" Foreground="#FFF0F0F0" HorizontalContentAlignment="Center" FontWeight="Bold" FontSize="8"/>
-                            <Label x:Name="Label_IVCC" Content="IVC Client&#xD;&#xA;(MP Radio)" HorizontalAlignment="Left" Margin="361,0,0,0" VerticalAlignment="Bottom" Foreground="#FFF0F0F0" HorizontalContentAlignment="Center" FontWeight="Bold" FontSize="8"/>
-                            <Label x:Name="Label_IVCS" Content="IVC Server&#xD;&#xA;(MP Radio)" HorizontalAlignment="Left" Margin="428,0,0,0" VerticalAlignment="Bottom" Foreground="#FFF0F0F0" HorizontalContentAlignment="Center" FontWeight="Bold" FontSize="8"/>
-                            <Label x:Name="Label_AVC" Content="Avionics&#xD;&#xA;Configurator" HorizontalAlignment="Left" Margin="501,0,0,0" VerticalAlignment="Bottom" Foreground="#FFF0F0F0" HorizontalContentAlignment="Center" FontWeight="Bold" FontSize="8"/>
-                            <Label x:Name="Label_EDIT" Content="Editor&#xD;&#xA;" HorizontalAlignment="Left" Margin="575,0,0,0" VerticalAlignment="Bottom" Foreground="#FFF0F0F0" HorizontalContentAlignment="Center" FontWeight="Bold" FontSize="8"/>
+                            <Label x:Name="Label_UPD" Content="Update&#xD;&#xA;" Margin="18,0,0,0"/>
+                            <Label x:Name="Label_CFG" Content="Config&#xD;&#xA;" Margin="88,0,0,0"/>
+                            <Label x:Name="Label_MMC" Content="Display&#xD;&#xA;Config" Margin="158,0,0,0"/>
+                            <Label x:Name="Label_RTTC" Content="RTT Client&#xD;&#xA;" Margin="220,0,0,0"/>
+                            <Label x:Name="Label_RTTS" Content="RTT Server&#xD;&#xA;" Margin="290,0,0,0"/>
+                            <Label x:Name="Label_IVCC" Content="IVC Client&#xD;&#xA;(MP Radio)" Margin="361,0,0,0"/>
+                            <Label x:Name="Label_IVCS" Content="IVC Server&#xD;&#xA;(MP Radio)" Margin="428,0,0,0"/>
+                            <Label x:Name="Label_AVC" Content="Avionics&#xD;&#xA;Configurator" Margin="501,0,0,0"/>
+                            <Label x:Name="Label_EDIT" Content="Editor&#xD;&#xA;" Margin="575,0,0,0"/>
                         </Grid>
                     </Border>
                     <CheckBox x:Name="ApplicationOverride" Content="Launch without any setup override" HorizontalAlignment="Right" Margin="0,0,14.667,97.667" VerticalAlignment="Bottom" Background="#FFECFF71" />
@@ -204,7 +226,29 @@
                             </LinearGradientBrush>
                         </Border.Background>
                         <Grid HorizontalAlignment="Stretch" Height="auto" Margin="0,0,0,0" VerticalAlignment="Stretch" Width="auto">
-                            <Button x:Name="Launch_WDP" BorderThickness="10" BorderBrush="Black" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="20,0,0,33.333" Height="32" Width="32" Click="Launch_Third" MouseEnter="MouseEnterLauncher" MouseLeave="MouseLeaveLauncher">
+                            <Grid.Resources>
+                                <Style TargetType="Button">
+                                    <Setter Property="BorderThickness" Value="10" />
+                                    <Setter Property="BorderBrush" Value="Black" />
+                                    <Setter Property="HorizontalAlignment" Value="Left" />
+                                    <Setter Property="VerticalAlignment" Value="Bottom" />
+                                    <Setter Property="Width" Value="32" />
+                                    <Setter Property="Height" Value="32" />
+                                    <EventSetter Event="Click" Handler="Launch_Third"/>
+                                    <EventSetter Event="MouseEnter" Handler="MouseEnterLauncher"/>
+                                    <EventSetter Event="MouseLeave" Handler="MouseLeaveLauncher"/>
+                                </Style>
+                                <Style TargetType="Label">
+                                    <Setter Property="HorizontalAlignment" Value="Left" />
+                                    <Setter Property="VerticalAlignment" Value="Bottom" />
+                                    <Setter Property="Foreground" Value="#FFF0F0F0" />
+                                    <Setter Property="HorizontalContentAlignment" Value="Center" />
+                                    <Setter Property="FontWeight" Value="Bold" />
+                                    <Setter Property="FontSize" Value="8" />
+                                </Style>
+                            </Grid.Resources>
+
+                            <Button x:Name="Launch_WDP" Margin="20,0,0,33.333">
                                 <Button.Template>
                                     <ControlTemplate>
                                         <Image Source="/Resources/WDP.png"/>
@@ -212,39 +256,39 @@
                                 </Button.Template>
                             </Button>
 
-                            <Button x:Name="Launch_MC" BorderThickness="10" BorderBrush="Black" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="90,0,0,33.333" Height="32" Width="32" Click="Launch_Third" MouseEnter="MouseEnterLauncher" MouseLeave="MouseLeaveLauncher">
+                            <Button x:Name="Launch_MC" Margin="90,0,0,33.333">
                                 <Button.Template>
                                     <ControlTemplate>
                                         <Image Source="/Resources/MC.png"/>
                                     </ControlTemplate>
                                 </Button.Template>
                             </Button>
-                            <Button x:Name="Launch_WC" BorderThickness="10" BorderBrush="Black" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="160,0,0,33.333" Height="32" Width="32" Click="Launch_Third" MouseEnter="MouseEnterLauncher" MouseLeave="MouseLeaveLauncher">
+                            <Button x:Name="Launch_WC" Margin="160,0,0,33.333">
                                 <Button.Template>
                                     <ControlTemplate>
                                         <Image Source="/Resources/WC.png"/>
                                     </ControlTemplate>
                                 </Button.Template>
                             </Button>
-                            <Button x:Name="Launch_F4WX" BorderThickness="10" BorderBrush="Black" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="230,0,0,33.333" Height="32" Width="32" Click="Launch_Third" MouseEnter="MouseEnterLauncher" MouseLeave="MouseLeaveLauncher">
+                            <Button x:Name="Launch_F4WX" Margin="230,0,0,33.333">
                                 <Button.Template>
                                     <ControlTemplate>
                                         <Image Source="/Resources/F4WX.png"/>
                                     </ControlTemplate>
                                 </Button.Template>
                             </Button>
-                            <Button x:Name="Launch_F4RADAR" BorderThickness="10" BorderBrush="Black" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="300,0,0,33.333" Height="32" Width="32" Click="Launch_Third" MouseEnter="MouseEnterLauncher" MouseLeave="MouseLeaveLauncher">
+                            <Button x:Name="Launch_F4RADAR" Margin="300,0,0,33.333">
                                 <Button.Template>
                                     <ControlTemplate>
                                         <Image Source="/Resources/F4RADAR.png"/>
                                     </ControlTemplate>
                                 </Button.Template>
                             </Button>
-                            <Label x:Name="Label_WDP" Content="Weapon Delivery&#10;        Planner" HorizontalAlignment="Left" Margin="0,0,0,0.333" VerticalAlignment="Bottom" Foreground="#FFF0F0F0" HorizontalContentAlignment="Center" FontWeight="Bold" FontSize="8"/>
-                            <Label x:Name="Label_MC" Content="    Mission&#xA;Commander" HorizontalAlignment="Left" Margin="75,0,0,0.333" VerticalAlignment="Bottom" Foreground="#FFF0F0F0" HorizontalContentAlignment="Center" FontWeight="Bold" FontSize="8"/>
-                            <Label x:Name="Label_WC" Content="   Weather&#xA;Commander" HorizontalAlignment="Left" Margin="147,0,0,0.333" VerticalAlignment="Bottom" Foreground="#FFF0F0F0" HorizontalContentAlignment="Center" FontWeight="Bold" FontSize="8"/>
-                            <Label x:Name="Label_F4WX" Content="      F4Wx&#xA;Real Weather" HorizontalAlignment="Left" Margin="216,0,0,0.333" VerticalAlignment="Bottom" Foreground="#FFF0F0F0" HorizontalContentAlignment="Center" FontWeight="Bold" FontSize="8"/>
-                            <Label x:Name="Label_F4RADAR" Content="     F4 RADAR&#xA;C2(AWACS) Tool" HorizontalAlignment="Left" Margin="281,0,0,0.333" VerticalAlignment="Bottom" Foreground="#FFF0F0F0" HorizontalContentAlignment="Center" FontWeight="Bold" FontSize="8"/>
+                            <Label x:Name="Label_WDP" Content="Weapon Delivery&#10;        Planner" Margin="0,0,0,0.333"/>
+                            <Label x:Name="Label_MC" Content="    Mission&#xA;Commander" Margin="75,0,0,0.333"/>
+                            <Label x:Name="Label_WC" Content="   Weather&#xA;Commander" Margin="147,0,0,0.333"/>
+                            <Label x:Name="Label_F4WX" Content="      F4Wx&#xA;Real Weather" Margin="216,0,0,0.333"/>
+                            <Label x:Name="Label_F4RADAR" Content="     F4 RADAR&#xA;C2(AWACS) Tool" Margin="281,0,0,0.333"/>
                         </Grid>
                     </Border>
                     <Button x:Name="Launch_BMS_Large" Content="LAUNCH" Style="{StaticResource AccentedSquareButtonStyle}" Controls:ControlsHelper.ContentCharacterCasing="Normal" HorizontalAlignment="Right" Margin="0,0,9.667,20.333" VerticalAlignment="Bottom" Width="208" Click="Launch_Click" Height="72" Background="#CC2494FF" BorderBrush="{x:Null}" FontSize="24" Grid.Row="1"/>
@@ -257,30 +301,53 @@
                         </ListBox.Resources>
                     </ListBox>
                     <Grid HorizontalAlignment="Left" Height="127" Margin="46,0,0,191.333" VerticalAlignment="Bottom" Width="953">
-                        <Label Content="Theater :" HorizontalAlignment="Left" VerticalAlignment="Top" FontWeight="Bold" />
+                        <Grid.Resources>
+                            <Style TargetType="Label"
+                                BasedOn="{StaticResource {x:Type Label}}">
+                                <Setter Property="HorizontalAlignment" Value="Left" />
+                                <Setter Property="VerticalAlignment" Value="Top" />
+                                <Setter Property="FontWeight" Value="Bold" />
+                                <Setter Property="Foreground" Value="#80FFFFFF" />
+                            </Style>
+                            <Style TargetType="Controls:ToggleSwitch"
+                                BasedOn="{StaticResource {x:Type Controls:ToggleSwitch}}">
+                                <Setter Property="FontSize" Value="11" />
+                                <Setter Property="HorizontalAlignment" Value="Left" />
+                                <Setter Property="HorizontalContentAlignment" Value="Left" />
+                                <Setter Property="VerticalAlignment" Value="Top" />
+                            </Style>
+                            <Style TargetType="RadioButton"
+                                BasedOn="{StaticResource {x:Type RadioButton}}">
+                                <Setter Property="HorizontalAlignment" Value="Left" />
+                                <Setter Property="VerticalAlignment" Value="Top" />
+                            </Style>
+                        </Grid.Resources>
+                        
+                        <Label Content="Theater :"/>
                         <ComboBox x:Name="Dropdown_TheaterList" Background="#80F0F0F0" Foreground="#FF191919" HorizontalAlignment="Left" Margin="180,4,0,0" VerticalAlignment="Top" Width="239" SelectionChanged="Dropdown_TheaterList_SelectionChanged"/>
 
                         <Button x:Name="Launch_TheaterConfig" Content="Theater Config" Style="{StaticResource AccentedSquareButtonStyle}" Controls:ControlsHelper.ContentCharacterCasing="Normal" Margin="424,2,429,0" VerticalAlignment="Top" Click="Launch_TheaterConfig_Click" FontSize="10" RenderTransformOrigin="-0.033,0.5"/>
 
-                        <Label Content="Command Line :" HorizontalAlignment="Left" VerticalAlignment="Top" FontWeight="Bold" Margin="0,96,0,-27" />
+                        <Label Content="Command Line :" Margin="0,96,0,-27" />
 
-                        <Label x:Name="Label_VR" Content="Virtual Reality:" HorizontalAlignment="Left" Margin="0,64,0,0" VerticalAlignment="Top" FontWeight="Bold" />
-                        <RadioButton x:Name="VR_NoVR" GroupName="VR" Content="No VR" HorizontalAlignment="Left" Margin="181,69,0,0" VerticalAlignment="Top"/>
-                        <RadioButton x:Name="VR_SteamVR" GroupName="VR" Content="SteamVR" HorizontalAlignment="Left" Margin="250,69,0,0" VerticalAlignment="Top" Click="Misc_VR_Click"/>
-                        <RadioButton x:Name="VR_OpenXR" GroupName="VR" Content="OpenXR" HorizontalAlignment="Left" Margin="329,69,0,0" VerticalAlignment="Top" RenderTransformOrigin="-7.082,0.583"/>
+                        <Label x:Name="Label_VR" Content="Virtual Reality:" Margin="0,64,0,0"/>
+                        <RadioButton x:Name="VR_NoVR" GroupName="VR" Content="No VR" Margin="181,69,0,0"/>
+                        <RadioButton x:Name="VR_SteamVR" GroupName="VR" Content="SteamVR" Margin="250,69,0,0" Click="Misc_VR_Click"/>
+                        <RadioButton x:Name="VR_OpenXR" GroupName="VR" Content="OpenXR" Margin="329,69,0,0" RenderTransformOrigin="-7.082,0.583"/>
 
-                        <Label x:Name="Label_RTT" Content="Export RTT Textures:" HorizontalAlignment="Left" Margin="525,64,0,0" VerticalAlignment="Top" FontWeight="Bold"/>
-                        <RadioButton x:Name="RTT_Disable" GroupName="RTT" Content="Disable" HorizontalAlignment="Left" Margin="660,69,0,0" VerticalAlignment="Top"/>
-                        <RadioButton x:Name="RTT_Enable" GroupName="RTT" Content="Enable" HorizontalAlignment="Left" Margin="730,69,0,0" VerticalAlignment="Top"/>
+                        <Label x:Name="Label_RTT" Content="Export RTT Textures:" Margin="525,64,0,0"/>
+                        <RadioButton x:Name="RTT_Disable" GroupName="RTT" Content="Disable" Margin="660,69,0,0"/>
+                        <RadioButton x:Name="RTT_Enable" GroupName="RTT" Content="Enable" Margin="730,69,0,0"/>
 
-                        <Label Content="Documentation and Manuals :" HorizontalAlignment="Left" Margin="0,32,0,0" VerticalAlignment="Top" FontWeight="Bold" />
+                        <Label Content="Documentation and Manuals :" Margin="0,32,0,0"/>
                         <Button x:Name="OpenDocs" Content="Open Docs Folder" Style="{StaticResource AccentedSquareButtonStyle}" Controls:ControlsHelper.ContentCharacterCasing="Normal" HorizontalAlignment="Left" Margin="179,34,0,0" VerticalAlignment="Top" Width="141" Click="OpenDocs_Click" FontSize="10" Height="10"/>
 
-                        <Controls:ToggleSwitch x:Name="CMD_ACMI" OnLabel="ACMI On" OffLabel="ACMI Off" HorizontalAlignment="Left" HorizontalContentAlignment="Left" FontSize="11" Margin="178,94,0,0" VerticalAlignment="Top" Width="120"/>
-                        <Controls:ToggleSwitch x:Name="CMD_WINDOW" OnLabel="WINDOW On" OffLabel="WINDOW Off" HorizontalAlignment="Left" HorizontalContentAlignment="Left" FontSize="11" Margin="313,94,0,0" VerticalAlignment="Top" Width="142" Click="CMD_WINDOW_Click"/>
-                        <Controls:ToggleSwitch x:Name="CMD_NOMOVIE" OnLabel="NOMOVIE On" OffLabel="NOMOVIE Off" HorizontalAlignment="Left" HorizontalContentAlignment="Left" FontSize="11" Margin="472,94,0,0" VerticalAlignment="Top" Width="144"/>
-                        <Controls:ToggleSwitch x:Name="CMD_EF" OnLabel="EYEFLY On" OffLabel="EYEFLY Off" HorizontalAlignment="Left" HorizontalContentAlignment="Left" FontSize="11" Margin="633,94,0,0" VerticalAlignment="Top" Width="128"/>
-                        <Controls:ToggleSwitch x:Name="CMD_MONO" OnLabel="DEBUG On" OffLabel="DEBUG Off" HorizontalAlignment="Left" HorizontalContentAlignment="Left" FontSize="11" Margin="776,94,0,0" VerticalAlignment="Top" Width="130"/>
+                        <Controls:ToggleSwitch x:Name="CMD_ACMI" OnLabel="ACMI On" OffLabel="ACMI Off" Margin="178,94,0,0"/>
+                        <Controls:ToggleSwitch x:Name="CMD_WINDOW" OnLabel="WINDOW On" OffLabel="WINDOW Off" Margin="313,94,0,0" Click="CMD_WINDOW_Click"/>
+                        <Controls:ToggleSwitch x:Name="CMD_NOMOVIE" OnLabel="NOMOVIE On" OffLabel="NOMOVIE Off" Margin="472,94,0,0"/>
+                        <Controls:ToggleSwitch x:Name="CMD_EF" OnLabel="EYEFLY On" OffLabel="EYEFLY Off" Margin="633,94,0,0"/>
+                        <Controls:ToggleSwitch x:Name="CMD_MONO" OnLabel="DEBUG On" OffLabel="DEBUG Off" Margin="776,94,0,0"/>
+                        
                         <Button x:Name="CMD_BW" Content="BW : 1024" HorizontalAlignment="Left" Margin="881,66,0,0" VerticalAlignment="Top" Width="64" Click="CMD_BW_Click"/>
                         <Controls:ToggleSwitch x:Name="AB_Test" Visibility="Hidden" OffLabel="A" OnLabel="B" Margin="700,10,10,10" HorizontalAlignment="Left" VerticalAlignment="Top" Width="85" Height="36" />
                     </Grid>

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -359,35 +359,73 @@
             </TabItem>
             <TabItem Header="AXISASSIGN" Margin="535.333,-40,-535,40.333">
                 <Grid>
+                    <Grid.Resources>
+                        <Style x:Key="AxisHeading" TargetType="Label"
+                             BasedOn="{StaticResource {x:Type Label}}">
+                            <Setter Property="FontSize" Value="16"/>
+                            <Setter Property="FontWeight" Value="Bold"/>
+                            <Setter Property="FontStyle" Value="Oblique"/>
+                            <Setter Property="HorizontalAlignment" Value="Left"/>
+                            <Setter Property="VerticalAlignment" Value="Top"/>
+                            <Setter Property="Height" Value="41"/>
+                            <Setter Property="Width" Value="349"/>
+                        </Style>
+                        <Style x:Key="AxisTitle" TargetType="Label"
+                             BasedOn="{StaticResource {x:Type Label}}">
+                            <Setter Property="FontSize" Value="16"/>
+                            <Setter Property="FontWeight" Value="Bold"/>
+                            <Setter Property="HorizontalAlignment" Value="Left"/>
+                            <Setter Property="VerticalAlignment" Value="Top"/>
+                            <Setter Property="Height" Value="34"/>
+                            <Setter Property="Width" Value="150"/>
+                        </Style>
+                        <Style x:Key="AssignButton" TargetType="Button"
+                             BasedOn="{StaticResource {x:Type Button}}">
+                            <Setter Property="HorizontalAlignment" Value="Left"/>
+                            <Setter Property="VerticalAlignment" Value="Top"/>
+                            <Setter Property="Width" Value="74"/>
+                            <Setter Property="Height" Value="27"/>
+                            <Setter Property="Content" Value="Assign"/>
+                            <EventSetter Event="Click" Handler="Assign_Click"/>
+                        </Style>
+                        <Style x:Key="AxisBar"
+                             TargetType="{x:Type Controls:MetroProgressBar}"
+                             BasedOn="{StaticResource {x:Type Controls:MetroProgressBar}}">
+                            <Setter Property="Width" Value="256"/>
+                            <Setter Property="Height" Value="10"/>
+                            <Setter Property="HorizontalAlignment" Value="Left"/>
+                            <Setter Property="VerticalAlignment" Value="Top"/>
+                        </Style>
+                    </Grid.Resources>
                     <TabControl HorizontalAlignment="Stretch" Height="Auto" VerticalAlignment="Stretch" Width="auto" Margin="10,0" Background="{x:Null}">
                         <TabItem Header=" FLIGHT CONTROL &amp; AVIONICS" Controls:ControlsHelper.HeaderFontSize="24" Margin="205,-46,-205,46">
                             <Grid Margin="0,-35,0,23.667" Background="#7F202020" x:Name="BackGroundBox1">
                                 <!-- Roll Axis -->
                                 <Grid HorizontalAlignment="Left" Height="180" VerticalAlignment="Top" Width="480">
-                                    <Label Content="SSC (Side Stick Controller)" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" FontSize="16" FontWeight="Bold" FontStyle="Oblique" Height="41" Width="349"/>
+                                    <Label Content="SSC (Side Stick Controller)" Margin="10,10,0,0" Style="{StaticResource AxisHeading}"/>
 
-                                    <Label Content="Roll : " HorizontalAlignment="Left" Margin="32,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="60" FontWeight="Bold"/>
+                                    <Label Content="Roll : " Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Roll" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_Roll" HorizontalAlignment="Left" Margin="32,85,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="Roll" Content="Assign" HorizontalAlignment="Left" Margin="320,77,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27" RenderTransformOrigin="0.216,1.519"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_Roll" Margin="32,85,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="Roll" Margin="320,77,0,0" RenderTransformOrigin="0.216,1.519" Style="{StaticResource AssignButton}"/>
 
-                                    <Label Content="Pitch :" HorizontalAlignment="Left" Margin="32,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="60" FontWeight="Bold"/>
+                                    <Label Content="Pitch :" Margin="32,100,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Pitch" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_Pitch" HorizontalAlignment="Left" Margin="32,134,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="Pitch" Content="Assign" HorizontalAlignment="Left" Margin="320,126,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_Pitch" Margin="32,134,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="Pitch" Margin="320,126,0,0" Style="{StaticResource AssignButton}"/>
                                 </Grid>
                                 <Grid HorizontalAlignment="Left" Height="180" Margin="0,180,0,0" VerticalAlignment="Top" Width="480">
-                                    <Label Content="TQS (Throttle Quadrant System)" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" FontSize="16" FontWeight="Bold" FontStyle="Oblique" Height="46" Width="458"/>
+                                    <Label Content="TQS (Throttle Quadrant System)" Margin="10,10,0,0" Style="{StaticResource AxisHeading}"/>
 
-                                    <Label Content="Throttle :" HorizontalAlignment="Left" Margin="32,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="80" FontWeight="Bold"/>
+                                    <Label Content="Throttle :" Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Throttle" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_Throttle" HorizontalAlignment="Left" Margin="32,85,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="Throttle" Content="Assign" HorizontalAlignment="Left" Margin="320,77,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_Throttle" Margin="32,85,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="Throttle" Margin="320,77,0,0" Style="{StaticResource AssignButton}"/>
 
-                                    <Label Content="Throttle Right :" HorizontalAlignment="Left" Margin="32,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="128" FontWeight="Bold"/>
+                                    <Label Content="Throttle Right :" Margin="32,100,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Throttle_Right" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_Throttle_Right" HorizontalAlignment="Left" Margin="32,134,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="Throttle_Right" Content="Assign" HorizontalAlignment="Left" Margin="320,126,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_Throttle_Right" Margin="32,134,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="Throttle_Right" Margin="320,126,0,0" Style="{StaticResource AssignButton}"/>
 
                                     <Label x:Name="AB_Throttle" Content="AB" HorizontalAlignment="Left" HorizontalContentAlignment="Center" Margin="32,77,0,0" VerticalAlignment="Top" Foreground="#80FFFFFF" FontSize="11" Width="256"/>
                                     <Label x:Name="AB_Throttle_Right" Content="AB" HorizontalAlignment="Left" HorizontalContentAlignment="Center" Margin="32,126,0,0" VerticalAlignment="Top" Foreground="#80FFFFFF" FontSize="11" Width="256"/>
@@ -398,40 +436,40 @@
                                         <ColumnDefinition Width="78*"/>
                                         <ColumnDefinition Width="153*"/>
                                     </Grid.ColumnDefinitions>
-                                    <Label Content="Rudder" HorizontalAlignment="Left" Margin="10,10,0,177" FontSize="16" FontWeight="Bold" FontStyle="Oblique" Width="422" Grid.ColumnSpan="3"/>
+                                    <Label Content="Rudder" Margin="10,10,0,177" Style="{StaticResource AxisHeading}" Grid.ColumnSpan="3"/>
 
-                                    <Label Content="Yaw :" HorizontalAlignment="Left" Margin="32,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="60" FontWeight="Bold"/>
+                                    <Label Content="Yaw :" Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Yaw" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100" Grid.ColumnSpan="2"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_Yaw" HorizontalAlignment="Left" Margin="32,85,0,0" VerticalAlignment="Top" Width="256" Height="10" Grid.ColumnSpan="2"/>
-                                    <Button x:Name="Yaw" Content="Assign" HorizontalAlignment="Left" Margin="71.778,77,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27" Grid.ColumnSpan="2" Grid.Column="1"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_Yaw" Margin="32,85,0,0" Style="{StaticResource AxisBar}" Grid.ColumnSpan="2"/>
+                                    <Button x:Name="Yaw" Margin="71.778,77,0,0" Style="{StaticResource AssignButton}" Grid.ColumnSpan="2" Grid.Column="1"/>
 
-                                    <Label Content="Toe Brake :" HorizontalAlignment="Left" Margin="32,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100" FontWeight="Bold"/>
+                                    <Label Content="Toe Brake :" Margin="32,100,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Toe_Brake" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100" Grid.ColumnSpan="2"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_Toe_Brake" HorizontalAlignment="Left" Margin="32,134,0,0" VerticalAlignment="Top" Width="256" Height="10" Grid.ColumnSpan="2"/>
-                                    <Button x:Name="Toe_Brake" Content="Assign" HorizontalAlignment="Left" Margin="71.778,126,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27" Grid.ColumnSpan="2" Grid.Column="1"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_Toe_Brake" Margin="32,134,0,0" Style="{StaticResource AxisBar}" Grid.ColumnSpan="2"/>
+                                    <Button x:Name="Toe_Brake" Margin="71.778,126,0,0" Style="{StaticResource AssignButton}" Grid.ColumnSpan="2" Grid.Column="1"/>
 
-                                    <Label Content="Toe Brake Right :" HorizontalAlignment="Left" Margin="32,149,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="132" FontWeight="Bold"/>
+                                    <Label Content="Toe Brake Right :" Margin="32,149,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Toe_Brake_Right" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,149,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100" Grid.ColumnSpan="2"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_Toe_Brake_Right" HorizontalAlignment="Left" Margin="32,183,0,0" VerticalAlignment="Top" Width="256" Height="10" Grid.ColumnSpan="2"/>
-                                    <Button x:Name="Toe_Brake_Right" Content="Assign" HorizontalAlignment="Left" Margin="71.778,175,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27" Grid.ColumnSpan="2" Grid.Column="1"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_Toe_Brake_Right" Margin="32,183,0,0" Style="{StaticResource AxisBar}" Grid.ColumnSpan="2"/>
+                                    <Button x:Name="Toe_Brake_Right" Margin="71.778,175,0,0" Style="{StaticResource AssignButton}" Grid.ColumnSpan="2" Grid.Column="1"/>
                                 </Grid>
                                 <Grid HorizontalAlignment="Left" Height="228" Margin="480,0,0,0" VerticalAlignment="Top" Width="480">
-                                    <Label Content="TRIM Panel" HorizontalAlignment="Left" Margin="10,10,-18,177" FontSize="16" FontWeight="Bold" FontStyle="Oblique" Width="422"/>
+                                    <Label Content="TRIM Panel" Margin="10,10,-18,177" Style="{StaticResource AxisHeading}"/>
 
-                                    <Label Content="Trim Roll :" HorizontalAlignment="Left" Margin="32,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100" FontWeight="Bold"/>
+                                    <Label Content="Trim Roll :" Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Trim_Roll" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_Trim_Roll" HorizontalAlignment="Left" Margin="32,85,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="Trim_Roll" Content="Assign" HorizontalAlignment="Left" Margin="320,77,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_Trim_Roll" Margin="32,85,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="Trim_Roll" Margin="320,77,0,0" Style="{StaticResource AssignButton}"/>
 
-                                    <Label Content="Trim Pitch :" HorizontalAlignment="Left" Margin="32,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100" FontWeight="Bold"/>
+                                    <Label Content="Trim Pitch :" Margin="32,100,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Trim_Pitch" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_Trim_Pitch" HorizontalAlignment="Left" Margin="32,134,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="Trim_Pitch" Content="Assign" HorizontalAlignment="Left" Margin="320,126,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_Trim_Pitch" Margin="32,134,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="Trim_Pitch" Margin="320,126,0,0" Style="{StaticResource AssignButton}"/>
 
-                                    <Label Content="Trim Yaw :" HorizontalAlignment="Left" Margin="32,149,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100" FontWeight="Bold"/>
+                                    <Label Content="Trim Yaw :" Margin="32,149,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Trim_Yaw" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,149,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_Trim_Yaw" HorizontalAlignment="Left" Margin="32,183,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="Trim_Yaw" Content="Assign" HorizontalAlignment="Left" Margin="320,175,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_Trim_Yaw" Margin="32,183,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="Trim_Yaw" Margin="320,175,0,0" Style="{StaticResource AssignButton}"/>
                                 </Grid>
                                 <Grid HorizontalAlignment="Left" Height="40" Margin="346,336,0,0" VerticalAlignment="Top" Width="480">
                                     <Grid.ColumnDefinitions>
@@ -441,27 +479,27 @@
                                 </Grid>
                                 <Grid HorizontalAlignment="Left" Height="77" Margin="381,498,0,0" VerticalAlignment="Top" Width="475"/>
                                 <Grid HorizontalAlignment="Left" Height="278" VerticalAlignment="Top" Width="480" Margin="480,233,0,0">
-                                    <Label Content="TQS Avionics" HorizontalAlignment="Left" Margin="10,10,-18,177" FontSize="16" FontWeight="Bold" FontStyle="Oblique" Width="422"/>
+                                    <Label Content="TQS Avionics" Margin="10,10,-18,177" Style="{StaticResource AxisHeading}"/>
 
-                                    <Label Content="Antenna Elev :" HorizontalAlignment="Left" Margin="32,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="128" FontWeight="Bold"/>
+                                    <Label Content="Antenna Elev :" Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Radar_Antenna_Elevation" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_Radar_Antenna_Elevation" HorizontalAlignment="Left" Margin="32,85,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="Radar_Antenna_Elevation" Content="Assign" HorizontalAlignment="Left" Margin="320,77,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_Radar_Antenna_Elevation" Margin="32,85,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="Radar_Antenna_Elevation" Margin="320,77,0,0" Style="{StaticResource AssignButton}"/>
 
-                                    <Label Content="Cursor X :" HorizontalAlignment="Left" Margin="32,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="128" FontWeight="Bold"/>
+                                    <Label Content="Cursor X :" Margin="32,100,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Cursor_X" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_Cursor_X" HorizontalAlignment="Left" Margin="32,134,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="Cursor_X" Content="Assign" HorizontalAlignment="Left" Margin="320,126,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_Cursor_X" Margin="32,134,0,0" VerticalAlignment="Top" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="Cursor_X" Margin="320,126,0,0" Style="{StaticResource AssignButton}"/>
 
-                                    <Label Content="Cursor Y :" HorizontalAlignment="Left" Margin="32,149,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="128" FontWeight="Bold"/>
+                                    <Label Content="Cursor Y :" Margin="32,149,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Cursor_Y" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,149,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_Cursor_Y" HorizontalAlignment="Left" Margin="32,183,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="Cursor_Y" Content="Assign" HorizontalAlignment="Left" Margin="320,175,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_Cursor_Y" Margin="32,183,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="Cursor_Y" Margin="320,175,0,0" Style="{StaticResource AssignButton}"/>
 
-                                    <Label Content="Range Knob :" HorizontalAlignment="Left" Margin="32,198,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="128" FontWeight="Bold"/>
+                                    <Label Content="Range Knob :" Margin="32,198,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Range_Knob" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,198,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_Range_Knob" HorizontalAlignment="Left" Margin="32,232,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="Range_Knob" Content="Assign" HorizontalAlignment="Left" Margin="320,224,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_Range_Knob" Margin="32,232,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="Range_Knob" Margin="320,224,0,0" Style="{StaticResource AssignButton}"/>
                                 </Grid>
                                 <TextBlock HorizontalAlignment="Left" Margin="102,355,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Height="55" Width="378"><Run Text="&quot;Throttle&quot; works as "/><Run Text="&quot;"/><Run Text="Both Throttle"/><Run Text="&quot;"/><Run Text=" "/><Run Text="for twin engine jets"/><Run Text=" "/><Run Text="as long as no axis are applied to &quot;Throttle Right"/><Run Text="&quot; "/><Run Text="or it "/><Run Text="will work as &quot;Throttle Left&quot;"/><LineBreak/><Run Text="For F-16 &quot;Throttle&quot; works as a main engine."/><LineBreak/></TextBlock>
                                 <CheckBox x:Name="Misc_RollLinkedNWS" Content="Use Roll Axis for Steering while on the Ground enabling NWS." HorizontalAlignment="Left" Margin="512,533,0,0" VerticalAlignment="Top" Height="18" Width="349"/>
@@ -473,86 +511,86 @@
                         <TabItem Header="ICP, RADIOS, AUDIO &amp; ALTIMETER" Controls:ControlsHelper.HeaderFontSize="24" Margin="205,-46,-204.333,46">
                             <Grid Background="#7F202020" Margin="0,-35,0,23.667" x:Name="BackGroundBox2">
                                 <Grid HorizontalAlignment="Left" Height="278" VerticalAlignment="Top" Width="480">
-                                    <Label Content="ICP (Integrated Control Panel)" HorizontalAlignment="Left" Margin="10,10,-18,177" FontSize="16" FontWeight="Bold" FontStyle="Oblique" Width="422"/>
+                                    <Label Content="ICP (Integrated Control Panel)" Margin="10,10,-18,177" Style="{StaticResource AxisHeading}"/>
 
-                                    <Label Content="HUD Bright :" HorizontalAlignment="Left" Margin="32,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="128" FontWeight="Bold"/>
+                                    <Label Content="HUD Bright :" Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_HUD_Brightness" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_HUD_Brightness" HorizontalAlignment="Left" Margin="32,85,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="HUD_Brightness" Content="Assign" HorizontalAlignment="Left" Margin="320,77,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_HUD_Brightness" Margin="32,85,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="HUD_Brightness" Margin="320,77,0,0" Style="{StaticResource AssignButton}"/>
 
-                                    <Label Content="Reticle Depr :" HorizontalAlignment="Left" Margin="32,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="128" FontWeight="Bold"/>
+                                    <Label Content="Reticle Depr :" Margin="32,100,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Reticle_Depression" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_Reticle_Depression" HorizontalAlignment="Left" Margin="32,134,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="Reticle_Depression" Content="Assign" HorizontalAlignment="Left" Margin="320,126,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_Reticle_Depression" Margin="32,134,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="Reticle_Depression" Margin="320,126,0,0" Style="{StaticResource AssignButton}"/>
 
-                                    <Label Content="HMS Bright :" HorizontalAlignment="Left" Margin="32,149,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="128" FontWeight="Bold"/>
+                                    <Label Content="HMS Bright :" Margin="32,149,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_HMS_Brightness" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,149,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_HMS_Brightness" HorizontalAlignment="Left" Margin="32,183,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="HMS_Brightness" Content="Assign" HorizontalAlignment="Left" Margin="320,175,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_HMS_Brightness" Margin="32,183,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="HMS_Brightness" Margin="320,175,0,0" Style="{StaticResource AssignButton}"/>
 
-                                    <Label x:Name="Name_FLIR_Brightness"  Content="FLIR Bright :" HorizontalAlignment="Left" Margin="32,198,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="128" FontWeight="Bold"/>
+                                    <Label x:Name="Name_FLIR_Brightness"  Content="FLIR Bright :" Margin="32,198,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_FLIR_Brightness" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,198,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_FLIR_Brightness" HorizontalAlignment="Left" Margin="32,232,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="FLIR_Brightness" Content="Assign" HorizontalAlignment="Left" Margin="320,224,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_FLIR_Brightness" Margin="32,232,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="FLIR_Brightness" Margin="320,224,0,0" Style="{StaticResource AssignButton}"/>
                                 </Grid>
                                 <Grid HorizontalAlignment="Left" Height="527" VerticalAlignment="Top" Width="480" Margin="480,0,0,0">
-                                    <Label Content="AUDIO Panel" HorizontalAlignment="Left" Margin="10,10,-18,177" FontSize="16" FontWeight="Bold" FontStyle="Oblique" Width="422"/>
+                                    <Label Content="AUDIO Panel" Margin="10,10,-18,177" Style="{StaticResource AxisHeading}"/>
 
-                                    <Label Content="Intercom :" HorizontalAlignment="Left" Margin="32,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="128" FontWeight="Bold"/>
+                                    <Label Content="Intercom :" Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Intercom" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_Intercom" HorizontalAlignment="Left" Margin="32,85,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="Intercom" Content="Assign" HorizontalAlignment="Left" Margin="320,77,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_Intercom" Margin="32,85,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="Intercom" Margin="320,77,0,0" Style="{StaticResource AssignButton}"/>
 
-                                    <Label Content="COMM Ch 1 :" HorizontalAlignment="Left" Margin="32,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="128" FontWeight="Bold"/>
+                                    <Label Content="COMM Ch 1 :" Margin="32,100,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_COMM_Channel_1" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_COMM_Channel_1" HorizontalAlignment="Left" Margin="32,134,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="COMM_Channel_1" Content="Assign" HorizontalAlignment="Left" Margin="320,126,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_COMM_Channel_1" Margin="32,134,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="COMM_Channel_1" Margin="320,126,0,0" Style="{StaticResource AssignButton}"/>
 
-                                    <Label Content="COMM Ch 2 :" HorizontalAlignment="Left" Margin="32,149,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="128" FontWeight="Bold"/>
+                                    <Label Content="COMM Ch 2 :" Margin="32,149,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_COMM_Channel_2" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,149,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_COMM_Channel_2" HorizontalAlignment="Left" Margin="32,183,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="COMM_Channel_2" Content="Assign" HorizontalAlignment="Left" Margin="320,175,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_COMM_Channel_2" Margin="32,183,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="COMM_Channel_2" Margin="320,175,0,0" Style="{StaticResource AssignButton}"/>
 
-                                    <Label Content="MSL Vol :" HorizontalAlignment="Left" Margin="32,198,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="128" FontWeight="Bold"/>
+                                    <Label Content="MSL Vol :" Margin="32,198,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_MSL_Volume" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,198,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_MSL_Volume" HorizontalAlignment="Left" Margin="32,232,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="MSL_Volume" Content="Assign" HorizontalAlignment="Left" Margin="320,224,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_MSL_Volume" Margin="32,232,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="MSL_Volume" Margin="320,224,0,0" Style="{StaticResource AssignButton}"/>
 
-                                    <Label Content="Threat Vol :" HorizontalAlignment="Left" Margin="32,247,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="128" FontWeight="Bold"/>
+                                    <Label Content="Threat Vol :" Margin="32,247,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Threat_Volume" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,247,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_Threat_Volume" HorizontalAlignment="Left" Margin="32,281,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="Threat_Volume" Content="Assign" HorizontalAlignment="Left" Margin="320,273,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_Threat_Volume" Margin="32,281,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="Threat_Volume" Margin="320,273,0,0" Style="{StaticResource AssignButton}"/>
 
-                                    <Label x:Name="Name_AI_vs_IVC" Content="AI vs IVC :" HorizontalAlignment="Left" Margin="32,296,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="128" FontWeight="Bold"/>
+                                    <Label x:Name="Name_AI_vs_IVC" Content="AI vs IVC :" Margin="32,296,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_AI_vs_IVC" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,296,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_AI_vs_IVC" HorizontalAlignment="Left" Margin="32,330,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="AI_vs_IVC" Content="Assign" HorizontalAlignment="Left" Margin="320,322,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_AI_vs_IVC" Margin="32,330,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="AI_vs_IVC" Margin="320,322,0,0" Style="{StaticResource AssignButton}"/>
 
-                                    <Label x:Name="Name_ILS_Volume_Knob" Content="ILS Vol :" HorizontalAlignment="Left" Margin="32,343,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="128" FontWeight="Bold"/>
+                                    <Label x:Name="Name_ILS_Volume_Knob" Content="ILS Vol :" Margin="32,343,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_ILS_Volume_Knob" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,343,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_ILS_Volume_Knob" HorizontalAlignment="Left" Margin="32,377,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="ILS_Volume_Knob" Content="Assign" HorizontalAlignment="Left" Margin="320,369,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_ILS_Volume_Knob" Margin="32,377,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="ILS_Volume_Knob" Margin="320,369,0,0" Style="{StaticResource AssignButton}"/>
                                 </Grid>
                                 <Grid x:Name="Grid_HSI" HorizontalAlignment="Left" Height="180" VerticalAlignment="Top" Width="480" Margin="0,278,0,0">
-                                    <Label Content="HSI (Horizontal Situation Indicator)" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" FontSize="16" FontWeight="Bold" FontStyle="Oblique" Height="41" Width="349"/>
+                                    <Label Content="HSI (Horizontal Situation Indicator)" Margin="10,10,0,0" Style="{StaticResource AxisHeading}"/>
 
-                                    <Label Content="Course : " HorizontalAlignment="Left" Margin="32,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="90" FontWeight="Bold"/>
+                                    <Label Content="Course : " Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_HSI_Course_Knob" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_HSI_Course_Knob" HorizontalAlignment="Left" Margin="32,85,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="HSI_Course_Knob" Content="Assign" HorizontalAlignment="Left" Margin="320,77,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27" RenderTransformOrigin="0.216,1.519"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_HSI_Course_Knob" Margin="32,85,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="HSI_Course_Knob" Margin="320,77,0,0" Style="{StaticResource AssignButton}" RenderTransformOrigin="0.216,1.519"/>
 
-                                    <Label Content="Heading :" HorizontalAlignment="Left" Margin="32,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="90" FontWeight="Bold"/>
+                                    <Label Content="Heading :" Margin="32,100,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_HSI_Heading_Knob" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_HSI_Heading_Knob" HorizontalAlignment="Left" Margin="32,134,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="HSI_Heading_Knob" Content="Assign" HorizontalAlignment="Left" Margin="320,126,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_HSI_Heading_Knob" Margin="32,134,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="HSI_Heading_Knob" Margin="320,126,0,0" Style="{StaticResource AssignButton}"/>
                                 </Grid>
                                 <Grid x:Name="Grid_Altimeter" HorizontalAlignment="Left" Height="122" Margin="0,458,0,0" VerticalAlignment="Top" Width="480">
-                                    <Label Content="Altimeter" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" FontSize="16" FontWeight="Bold" FontStyle="Oblique" Height="46" Width="458"/>
+                                    <Label Content="Altimeter" Margin="10,10,0,0" Style="{StaticResource AxisHeading}"/>
 
-                                    <Label Content="Setting :" HorizontalAlignment="Left" Margin="32,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="80" FontWeight="Bold"/>
+                                    <Label Content="Setting :" Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Altimeter_Knob" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_Altimeter_Knob" HorizontalAlignment="Left" Margin="32,85,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="Altimeter_Knob" Content="Assign" HorizontalAlignment="Left" Margin="320,77,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_Altimeter_Knob" Margin="32,85,0,0" Style="{StaticResource AxisBar}"/>
+                                    <Button x:Name="Altimeter_Knob" Margin="320,77,0,0" Style="{StaticResource AssignButton}"/>
 
                                 </Grid>
                             </Grid>
@@ -561,17 +599,17 @@
                             <Grid Background="#7F202020" Margin="0,-35,0,23.667" x:Name="BackGroundBox4">
                                 <Grid HorizontalAlignment="Left" Height="278" VerticalAlignment="Top" Width="480" Grid.ColumnSpan="2"/>
                                 <Grid HorizontalAlignment="Left" Height="531" VerticalAlignment="Top" Width="480">
-                                    <Label Content="VIEWS" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" FontSize="16" FontWeight="Bold" FontStyle="Oblique" Height="41" Width="349"/>
+                                    <Label Content="VIEWS" Margin="10,10,0,0" Style="{StaticResource AxisHeading}"/>
 
-                                    <Label Content="FOV : " HorizontalAlignment="Left" Margin="32,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="128" FontWeight="Bold"/>
+                                    <Label Content="FOV : " Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_FOV" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
                                     <Controls:MetroProgressBar x:Name="Axis_FOV" HorizontalAlignment="Left" Margin="32,85,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="FOV" Content="Assign" HorizontalAlignment="Left" Margin="320,77,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27" RenderTransformOrigin="0.216,1.519"/>
+                                    <Button x:Name="FOV" Margin="320,77,0,0" Style="{StaticResource AssignButton}" RenderTransformOrigin="0.216,1.519"/>
 
-                                    <Label Content="Distance :" HorizontalAlignment="Left" Margin="32,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="128" FontWeight="Bold"/>
+                                    <Label Content="Distance :" Margin="32,100,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Camera_Distance" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Camera_Distance" HorizontalAlignment="Left" Margin="32,134,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
-                                    <Button x:Name="Camera_Distance" Content="Assign" HorizontalAlignment="Left" Margin="320,126,0,0" VerticalAlignment="Top" Width="74" Click="Assign_Click" Height="27"/>
+                                    <Button x:Name="Camera_Distance" Margin="320,126,0,0" Style="{StaticResource AssignButton}"/>
                                     <Controls:ToggleSwitch x:Name="Misc_TrackIRZ" OnLabel="TrackIR Zoom Fov" OffLabel="TrackIR Head Forward" HorizontalContentAlignment="Right" FontSize="11" HorizontalAlignment="Left" Margin="47,10,0,0" VerticalAlignment="Top" Width="347"/>
                                     <CheckBox x:Name="Misc_ExMouseLook" Content="External MouseLook" HorizontalAlignment="Left" Margin="32,192,0,0" VerticalAlignment="Top" />
                                     <TextBlock Text="Allows the mouse to control the camera for external views. Note that if this is enabled, controlling the external camera with the POV hat will be disabled." TextWrapping="Wrap" Margin="56,215,0,82" FontSize="10"/>

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -10,6 +10,11 @@
         Closed="Window_Closed" MouseDown="MetroWindow_MouseDown"
         FontSize="12" WindowStartupLocation="CenterScreen" ShowTitleBar="False" WindowStyle="None" Background="#a4a9ac" OverrideDefaultWindowCommandsBrush="#a4a9ac">
     <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Styles/Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
         <Style TargetType="Label">
             <Setter Property="Foreground" Value="#80FFFFFF" />
         </Style>
@@ -74,7 +79,8 @@
                 </DataTrigger>
             </Style.Triggers>
         </Style>
-    </Window.Resources>
+         </ResourceDictionary>
+        </Window.Resources>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="651*"/>
@@ -110,7 +116,6 @@
         <TabControl x:Name="LargeTab" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" SelectionChanged="TabControl_SelectionChanged" Margin="0,64,0.333,0.334" Background="{x:Null}" Grid.RowSpan="2">
             <TabItem Header="LAUNCHER" x:Name="Tab_Launcher" HorizontalAlignment="Center" Margin="535,-40,-535.333,40.333">
                 <Grid>
-
                     <Border BorderThickness="1" HorizontalAlignment="Left" Height="72" Width="638" Margin="48,0,0,97" VerticalAlignment="Bottom">
                         <Border.Background>
                             <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
@@ -301,52 +306,32 @@
                         </ListBox.Resources>
                     </ListBox>
                     <Grid HorizontalAlignment="Left" Height="127" Margin="46,0,0,191.333" VerticalAlignment="Bottom" Width="953">
-                        <Grid.Resources>
-                            <Style TargetType="Label"
-                                BasedOn="{StaticResource {x:Type Label}}">
-                                <Setter Property="HorizontalAlignment" Value="Left" />
-                                <Setter Property="VerticalAlignment" Value="Top" />
-                                <Setter Property="FontWeight" Value="Bold" />
-                                <Setter Property="Foreground" Value="#80FFFFFF" />
-                            </Style>
-                            <Style TargetType="Controls:ToggleSwitch"
-                                BasedOn="{StaticResource {x:Type Controls:ToggleSwitch}}">
-                                <Setter Property="FontSize" Value="11" />
-                                <Setter Property="HorizontalAlignment" Value="Left" />
-                                <Setter Property="HorizontalContentAlignment" Value="Left" />
-                                <Setter Property="VerticalAlignment" Value="Top" />
-                            </Style>
-                            <Style TargetType="RadioButton"
-                                BasedOn="{StaticResource {x:Type RadioButton}}">
-                                <Setter Property="HorizontalAlignment" Value="Left" />
-                                <Setter Property="VerticalAlignment" Value="Top" />
-                            </Style>
-                        </Grid.Resources>
-                        
-                        <Label Content="Theater :"/>
+
+                        <Label Content="Theater :" Style="{StaticResource LauncherTitle}"/>
                         <ComboBox x:Name="Dropdown_TheaterList" Background="#80F0F0F0" Foreground="#FF191919" HorizontalAlignment="Left" Margin="180,4,0,0" VerticalAlignment="Top" Width="239" SelectionChanged="Dropdown_TheaterList_SelectionChanged"/>
 
                         <Button x:Name="Launch_TheaterConfig" Content="Theater Config" Style="{StaticResource AccentedSquareButtonStyle}" Controls:ControlsHelper.ContentCharacterCasing="Normal" Margin="424,2,429,0" VerticalAlignment="Top" Click="Launch_TheaterConfig_Click" FontSize="10" RenderTransformOrigin="-0.033,0.5"/>
 
-                        <Label Content="Command Line :" Margin="0,96,0,-27" />
+                        <Label Content="Command Line :" Margin="0,96,0,-27" Style="{StaticResource LauncherTitle}"/>
 
-                        <Label x:Name="Label_VR" Content="Virtual Reality:" Margin="0,64,0,0"/>
-                        <RadioButton x:Name="VR_NoVR" GroupName="VR" Content="No VR" Margin="181,69,0,0"/>
-                        <RadioButton x:Name="VR_SteamVR" GroupName="VR" Content="SteamVR" Margin="250,69,0,0" Click="Misc_VR_Click"/>
-                        <RadioButton x:Name="VR_OpenXR" GroupName="VR" Content="OpenXR" Margin="329,69,0,0" RenderTransformOrigin="-7.082,0.583"/>
+                        <Label x:Name="Label_VR" Content="Virtual Reality:" Margin="0,64,0,0" Style="{StaticResource LauncherTitle}"/>
+                        <RadioButton x:Name="VR_NoVR" GroupName="VR" Content="No VR" Margin="181,69,0,0" Style="{StaticResource LauncherRadioButton}"/>
+                        <RadioButton x:Name="VR_SteamVR" GroupName="VR" Content="SteamVR" Margin="250,69,0,0" Click="Misc_VR_Click" Style="{StaticResource LauncherRadioButton}"/>
+                        <RadioButton x:Name="VR_OpenXR" GroupName="VR" Content="OpenXR" Margin="329,69,0,0" RenderTransformOrigin="-7.082,0.583" Style="{StaticResource LauncherRadioButton}"/>
 
-                        <Label x:Name="Label_RTT" Content="Export RTT Textures:" Margin="525,64,0,0"/>
-                        <RadioButton x:Name="RTT_Disable" GroupName="RTT" Content="Disable" Margin="660,69,0,0"/>
-                        <RadioButton x:Name="RTT_Enable" GroupName="RTT" Content="Enable" Margin="730,69,0,0"/>
+                        <Label x:Name="Label_RTT" Content="Export RTT Textures:" Margin="525,64,0,0" Style="{StaticResource LauncherTitle}"/>
+                        <RadioButton x:Name="RTT_Disable" GroupName="RTT" Content="Disable" Margin="660,69,0,0" Style="{StaticResource LauncherRadioButton}"/>
+                        <RadioButton x:Name="RTT_Enable" GroupName="RTT" Content="Enable" Margin="730,69,0,0" Style="{StaticResource LauncherRadioButton}"/>
 
-                        <Label Content="Documentation and Manuals :" Margin="0,32,0,0"/>
+                        <Label Content="Documentation and Manuals :" Margin="0,32,0,0" Style="{StaticResource LauncherTitle}"/>
                         <Button x:Name="OpenDocs" Content="Open Docs Folder" Style="{StaticResource AccentedSquareButtonStyle}" Controls:ControlsHelper.ContentCharacterCasing="Normal" HorizontalAlignment="Left" Margin="179,34,0,0" VerticalAlignment="Top" Width="141" Click="OpenDocs_Click" FontSize="10" Height="10"/>
 
-                        <Controls:ToggleSwitch x:Name="CMD_ACMI" OnLabel="ACMI On" OffLabel="ACMI Off" Margin="178,94,0,0"/>
-                        <Controls:ToggleSwitch x:Name="CMD_WINDOW" OnLabel="WINDOW On" OffLabel="WINDOW Off" Margin="313,94,0,0" Click="CMD_WINDOW_Click"/>
-                        <Controls:ToggleSwitch x:Name="CMD_NOMOVIE" OnLabel="NOMOVIE On" OffLabel="NOMOVIE Off" Margin="472,94,0,0"/>
-                        <Controls:ToggleSwitch x:Name="CMD_EF" OnLabel="EYEFLY On" OffLabel="EYEFLY Off" Margin="633,94,0,0"/>
-                        <Controls:ToggleSwitch x:Name="CMD_MONO" OnLabel="DEBUG On" OffLabel="DEBUG Off" Margin="776,94,0,0"/>
+                        <Controls:ToggleSwitch x:Name="CMD_ACMI" OnLabel="ACMI On" OffLabel="ACMI Off" Margin="178,94,0,0" Style="{StaticResource LauncherToggleSwitch}"/>
+
+                        <Controls:ToggleSwitch x:Name="CMD_WINDOW" OnLabel="WINDOW On" OffLabel="WINDOW Off" Margin="313,94,0,0" Click="CMD_WINDOW_Click" Style="{StaticResource LauncherToggleSwitch}"/>
+                        <Controls:ToggleSwitch x:Name="CMD_NOMOVIE" OnLabel="NOMOVIE On" OffLabel="NOMOVIE Off" Margin="472,94,0,0" Style="{StaticResource LauncherToggleSwitch}"/>
+                        <Controls:ToggleSwitch x:Name="CMD_EF" OnLabel="EYEFLY On" OffLabel="EYEFLY Off" Margin="633,94,0,0" Style="{StaticResource LauncherToggleSwitch}"/>
+                        <Controls:ToggleSwitch x:Name="CMD_MONO" OnLabel="DEBUG On" OffLabel="DEBUG Off" Margin="776,94,0,0" Style="{StaticResource LauncherToggleSwitch}"/>
                         
                         <Button x:Name="CMD_BW" Content="BW : 1024" HorizontalAlignment="Left" Margin="881,66,0,0" VerticalAlignment="Top" Width="64" Click="CMD_BW_Click"/>
                         <Controls:ToggleSwitch x:Name="AB_Test" Visibility="Hidden" OffLabel="A" OnLabel="B" Margin="700,10,10,10" HorizontalAlignment="Left" VerticalAlignment="Top" Width="85" Height="36" />
@@ -354,47 +339,16 @@
                     <ScrollViewer x:Name ="LogTextScroll" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Margin="48,57,563.667,349.333" Background="#54000000">
                         <TextBlock x:Name="News" HorizontalAlignment="Left" TextWrapping="Wrap" Text="" VerticalAlignment="Top" Height="Auto" Width="350" Margin="20,20,0,0" />
                     </ScrollViewer>
-                    <Label Content="News" HorizontalAlignment="Left" Margin="48,10,0,0" VerticalAlignment="Top" FontSize="24" FontWeight="Bold" FontStyle="Italic"/>
+                    <Label Content="News" Margin="48,10,0,0" Style="{StaticResource LauncherHeading}"/>
                 </Grid>
             </TabItem>
             <TabItem Header="AXISASSIGN" Margin="535.333,-40,-535,40.333">
                 <Grid>
                     <Grid.Resources>
-                        <Style x:Key="AxisHeading" TargetType="Label"
-                             BasedOn="{StaticResource {x:Type Label}}">
-                            <Setter Property="FontSize" Value="16"/>
-                            <Setter Property="FontWeight" Value="Bold"/>
-                            <Setter Property="FontStyle" Value="Oblique"/>
-                            <Setter Property="HorizontalAlignment" Value="Left"/>
-                            <Setter Property="VerticalAlignment" Value="Top"/>
-                            <Setter Property="Height" Value="41"/>
-                            <Setter Property="Width" Value="349"/>
-                        </Style>
-                        <Style x:Key="AxisTitle" TargetType="Label"
-                             BasedOn="{StaticResource {x:Type Label}}">
-                            <Setter Property="FontSize" Value="16"/>
-                            <Setter Property="FontWeight" Value="Bold"/>
-                            <Setter Property="HorizontalAlignment" Value="Left"/>
-                            <Setter Property="VerticalAlignment" Value="Top"/>
-                            <Setter Property="Height" Value="34"/>
-                            <Setter Property="Width" Value="150"/>
-                        </Style>
-                        <Style x:Key="AssignButton" TargetType="Button"
-                             BasedOn="{StaticResource {x:Type Button}}">
-                            <Setter Property="HorizontalAlignment" Value="Left"/>
-                            <Setter Property="VerticalAlignment" Value="Top"/>
-                            <Setter Property="Width" Value="74"/>
-                            <Setter Property="Height" Value="27"/>
-                            <Setter Property="Content" Value="Assign"/>
+                        <Style x:Key="AssignButton"
+                             TargetType="Button"
+                             BasedOn="{StaticResource AssignButtonBase}">
                             <EventSetter Event="Click" Handler="Assign_Click"/>
-                        </Style>
-                        <Style x:Key="AxisBar"
-                             TargetType="{x:Type Controls:MetroProgressBar}"
-                             BasedOn="{StaticResource {x:Type Controls:MetroProgressBar}}">
-                            <Setter Property="Width" Value="256"/>
-                            <Setter Property="Height" Value="10"/>
-                            <Setter Property="HorizontalAlignment" Value="Left"/>
-                            <Setter Property="VerticalAlignment" Value="Top"/>
                         </Style>
                     </Grid.Resources>
                     <TabControl HorizontalAlignment="Stretch" Height="Auto" VerticalAlignment="Stretch" Width="auto" Margin="10,0" Background="{x:Null}">


### PR DESCRIPTION
Cleanup of MainWindow.xaml by moving many inline styles from the LAUNCHER and AXISASSIGN tabs into a new Styles.xaml file.

The goal was to:
- Simplify MainWindow.xaml by reducing repeated inline styles.
- Centralize styling so that updates to labels, buttons, and toggles can be done in one place instead of editing each element individually

There are 3 commits in this branch
- Consolidating Launcher tab styles into its grid
- Consolidating Axis tab tyles into its grid
- Moving consolidated styles into the new Styles.xaml

I verified functionality and [appearance remain unchanged](https://i.imgur.com/EFQ3Tib.png).
There are no functional changes, this update was visual/organizational.