### PR TITLE
MahApps upgrade

### DIFF
--- a/Falcon BMS Alternative Launcher/App.xaml
+++ b/Falcon BMS Alternative Launcher/App.xaml
@@ -5,11 +5,13 @@
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
+                <!-- MahApps v2 base styles -->
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/Blue.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/BaseLight.xaml" />
+                <!-- Colors, Accents, BaseLight -->
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Themes/Light.Blue.xaml" />
+                <!-- Custom Styles -->
+                <ResourceDictionary Source="pack://application:,,,/Styles/Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/Falcon BMS Alternative Launcher/AppProperties.cs
+++ b/Falcon BMS Alternative Launcher/AppProperties.cs
@@ -24,7 +24,6 @@ namespace FalconBMS.Launcher
             bandWidthDefault                               = Properties.Settings.Default.CMD_BW;
             mainWindow.ApplicationOverride.IsChecked       = Properties.Settings.Default.NoOverride;
             mainWindow.Misc_RollLinkedNWS.IsChecked        = Properties.Settings.Default.Misc_RLNWS;
-            mainWindow.Misc_TrackIRZ.IsOn   = Properties.Settings.Default.Misc_TrackIRZ;
             mainWindow.Misc_ExMouseLook.IsChecked          = Properties.Settings.Default.Misc_ExMouseLook;
             mainWindow.Misc_SmartScalingOverride.IsChecked = Properties.Settings.Default.Misc_SmartScalingOverride;
             mainWindow.Misc_NaturalHeadMovement.IsChecked  = Properties.Settings.Default.Misc_NaturalHeadMovement;
@@ -62,6 +61,17 @@ namespace FalconBMS.Launcher
                 mainWindow.RTT_Enable.IsChecked = false;
             }
 
+            if (Properties.Settings.Default.Misc_TrackIRZ)
+            {
+                mainWindow.TrackIRZ_ZoomFOV.IsChecked = true;
+                mainWindow.TrackIRZ_HeadForward.IsChecked = false;
+            }
+            else
+            {
+                mainWindow.TrackIRZ_HeadForward.IsChecked = true;
+                mainWindow.TrackIRZ_ZoomFOV.IsChecked = false;
+            }
+
             mainWindow.CMD_BW.Content               = "BW : " + bandWidthDefault;
             mainWindow.AB_Throttle.Visibility       = Visibility.Hidden;
             mainWindow.AB_Throttle_Right.Visibility = Visibility.Hidden;
@@ -79,7 +89,7 @@ namespace FalconBMS.Launcher
             Properties.Settings.Default.CMD_BW                    = bandWidthDefault;
             Properties.Settings.Default.NoOverride                = (bool)mainWindow.ApplicationOverride.IsChecked;
             Properties.Settings.Default.Misc_RLNWS                = (bool)mainWindow.Misc_RollLinkedNWS.IsChecked;
-            Properties.Settings.Default.Misc_TrackIRZ             = (bool)mainWindow.Misc_TrackIRZ.IsOn;
+            Properties.Settings.Default.Misc_TrackIRZ             = (mainWindow.TrackIRZ_ZoomFOV.IsChecked == true);
             Properties.Settings.Default.Misc_ExMouseLook          = (bool)mainWindow.Misc_ExMouseLook.IsChecked;
             Properties.Settings.Default.Misc_SmartScalingOverride = (bool)mainWindow.Misc_SmartScalingOverride.IsChecked;
             Properties.Settings.Default.Misc_NaturalHeadMovement  = (bool)mainWindow.Misc_NaturalHeadMovement.IsChecked;

--- a/Falcon BMS Alternative Launcher/AppProperties.cs
+++ b/Falcon BMS Alternative Launcher/AppProperties.cs
@@ -16,15 +16,15 @@ namespace FalconBMS.Launcher
             this.mainWindow = mainWindow;
 
             // Load Buttons
-            mainWindow.CMD_ACMI.IsChecked                  = Properties.Settings.Default.CMD_ACMI;
-            mainWindow.CMD_WINDOW.IsChecked                = Properties.Settings.Default.CMD_WINDOW;
-            mainWindow.CMD_NOMOVIE.IsChecked               = Properties.Settings.Default.CMD_NOMOVIE;
-            mainWindow.CMD_EF.IsChecked                    = Properties.Settings.Default.CMD_EF;
-            mainWindow.CMD_MONO.IsChecked                  = Properties.Settings.Default.CMD_MONO;
+            mainWindow.CMD_ACMI.IsOn        = Properties.Settings.Default.CMD_ACMI;
+            mainWindow.CMD_WINDOW.IsOn      = Properties.Settings.Default.CMD_WINDOW;
+            mainWindow.CMD_NOMOVIE.IsOn     = Properties.Settings.Default.CMD_NOMOVIE;
+            mainWindow.CMD_EF.IsOn          = Properties.Settings.Default.CMD_EF;
+            mainWindow.CMD_MONO.IsOn        = Properties.Settings.Default.CMD_MONO;
             bandWidthDefault                               = Properties.Settings.Default.CMD_BW;
             mainWindow.ApplicationOverride.IsChecked       = Properties.Settings.Default.NoOverride;
             mainWindow.Misc_RollLinkedNWS.IsChecked        = Properties.Settings.Default.Misc_RLNWS;
-            mainWindow.Misc_TrackIRZ.IsChecked             = Properties.Settings.Default.Misc_TrackIRZ;
+            mainWindow.Misc_TrackIRZ.IsOn   = Properties.Settings.Default.Misc_TrackIRZ;
             mainWindow.Misc_ExMouseLook.IsChecked          = Properties.Settings.Default.Misc_ExMouseLook;
             mainWindow.Misc_SmartScalingOverride.IsChecked = Properties.Settings.Default.Misc_SmartScalingOverride;
             mainWindow.Misc_NaturalHeadMovement.IsChecked  = Properties.Settings.Default.Misc_NaturalHeadMovement;
@@ -71,15 +71,15 @@ namespace FalconBMS.Launcher
 
         public void SaveUISetup()
         {
-            Properties.Settings.Default.CMD_ACMI                  = (bool)mainWindow.CMD_ACMI.IsChecked;
-            Properties.Settings.Default.CMD_WINDOW                = (bool)mainWindow.CMD_WINDOW.IsChecked;
-            Properties.Settings.Default.CMD_NOMOVIE               = (bool)mainWindow.CMD_NOMOVIE.IsChecked;
-            Properties.Settings.Default.CMD_EF                    = (bool)mainWindow.CMD_EF.IsChecked;
-            Properties.Settings.Default.CMD_MONO                  = (bool)mainWindow.CMD_MONO.IsChecked;
+            Properties.Settings.Default.CMD_ACMI                  = (bool)mainWindow.CMD_ACMI.IsOn;
+            Properties.Settings.Default.CMD_WINDOW                = (bool)mainWindow.CMD_WINDOW.IsOn;
+            Properties.Settings.Default.CMD_NOMOVIE               = (bool)mainWindow.CMD_NOMOVIE.IsOn;
+            Properties.Settings.Default.CMD_EF                    = (bool)mainWindow.CMD_EF.IsOn;
+            Properties.Settings.Default.CMD_MONO                  = (bool)mainWindow.CMD_MONO.IsOn;
             Properties.Settings.Default.CMD_BW                    = bandWidthDefault;
             Properties.Settings.Default.NoOverride                = (bool)mainWindow.ApplicationOverride.IsChecked;
             Properties.Settings.Default.Misc_RLNWS                = (bool)mainWindow.Misc_RollLinkedNWS.IsChecked;
-            Properties.Settings.Default.Misc_TrackIRZ             = (bool)mainWindow.Misc_TrackIRZ.IsChecked;
+            Properties.Settings.Default.Misc_TrackIRZ             = (bool)mainWindow.Misc_TrackIRZ.IsOn;
             Properties.Settings.Default.Misc_ExMouseLook          = (bool)mainWindow.Misc_ExMouseLook.IsChecked;
             Properties.Settings.Default.Misc_SmartScalingOverride = (bool)mainWindow.Misc_SmartScalingOverride.IsChecked;
             Properties.Settings.Default.Misc_NaturalHeadMovement  = (bool)mainWindow.Misc_NaturalHeadMovement.IsChecked;

--- a/Falcon BMS Alternative Launcher/Falcon BMS Alternative Launcher.csproj
+++ b/Falcon BMS Alternative Launcher/Falcon BMS Alternative Launcher.csproj
@@ -62,11 +62,11 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ControlzEx, Version=3.0.2.4, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ControlzEx.3.0.2.4\lib\net45\ControlzEx.dll</HintPath>
+    <Reference Include="ControlzEx, Version=4.0.0.0, Culture=neutral, PublicKeyToken=69f1c32f803d307e, processorArchitecture=MSIL">
+      <HintPath>..\packages\ControlzEx.4.4.0\lib\net462\ControlzEx.dll</HintPath>
     </Reference>
-    <Reference Include="MahApps.Metro, Version=1.6.5.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MahApps.Metro.1.6.5\lib\net46\MahApps.Metro.dll</HintPath>
+    <Reference Include="MahApps.Metro, Version=2.0.0.0, Culture=neutral, PublicKeyToken=51482d6f650b2b3f, processorArchitecture=MSIL">
+      <HintPath>..\packages\MahApps.Metro.2.4.10\lib\net47\MahApps.Metro.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.DirectX, Version=1.0.2902.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
       <SpecificVersion>False</SpecificVersion>
@@ -77,10 +77,15 @@
       <HintPath>..\extlibs\Microsoft.DirectX.DirectInput.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualC" />
+    <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.19\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Entity" />
@@ -90,11 +95,9 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Forms.DataVisualization" />
-    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\ControlzEx.3.0.2.4\lib\net45\System.Windows.Interactivity.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />

--- a/Falcon BMS Alternative Launcher/Override/OverrideSettingFor432.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSettingFor432.cs
@@ -84,7 +84,7 @@ namespace FalconBMS.Launcher.Override
 
             // TrackIR Z-Axis(0:Z-axis 1:FOV)
             bs[276] = 0x00;
-            if (mainWindow.Misc_TrackIRZ.IsOn == true)
+            if (mainWindow.TrackIRZ_ZoomFOV.IsChecked == true)
                 bs[276] = 0x01;
 
             // External Mouselook

--- a/Falcon BMS Alternative Launcher/Override/OverrideSettingFor432.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSettingFor432.cs
@@ -84,7 +84,7 @@ namespace FalconBMS.Launcher.Override
 
             // TrackIR Z-Axis(0:Z-axis 1:FOV)
             bs[276] = 0x00;
-            if (mainWindow.Misc_TrackIRZ.IsChecked == true)
+            if (mainWindow.Misc_TrackIRZ.IsOn == true)
                 bs[276] = 0x01;
 
             // External Mouselook

--- a/Falcon BMS Alternative Launcher/Override/OverrideSettingFor433.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSettingFor433.cs
@@ -87,7 +87,7 @@ namespace FalconBMS.Launcher.Override
 
             // TrackIR Z-Axis(0:Z-axis 1:FOV)
             bs[336] = 0x00;
-            if (mainWindow.Misc_TrackIRZ.IsChecked == true)
+            if (mainWindow.Misc_TrackIRZ.IsOn == true)
                 bs[336] = 0x01;
 
             // External Mouselook

--- a/Falcon BMS Alternative Launcher/Override/OverrideSettingFor433.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSettingFor433.cs
@@ -87,7 +87,7 @@ namespace FalconBMS.Launcher.Override
 
             // TrackIR Z-Axis(0:Z-axis 1:FOV)
             bs[336] = 0x00;
-            if (mainWindow.Misc_TrackIRZ.IsOn == true)
+            if (mainWindow.TrackIRZ_ZoomFOV.IsChecked == true)
                 bs[336] = 0x01;
 
             // External Mouselook

--- a/Falcon BMS Alternative Launcher/Override/OverrideSettingFor434.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSettingFor434.cs
@@ -104,7 +104,7 @@ namespace FalconBMS.Launcher.Override
 
             // TrackIR Z-Axis(0:Z-axis 1:FOV)
             bs[336] = 0x00;
-            if (mainWindow.Misc_TrackIRZ.IsChecked == true)
+            if (mainWindow.Misc_TrackIRZ.IsOn == true)
                 bs[336] = 0x01;
 
             // External Mouselook

--- a/Falcon BMS Alternative Launcher/Override/OverrideSettingFor434.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSettingFor434.cs
@@ -104,7 +104,7 @@ namespace FalconBMS.Launcher.Override
 
             // TrackIR Z-Axis(0:Z-axis 1:FOV)
             bs[336] = 0x00;
-            if (mainWindow.Misc_TrackIRZ.IsOn == true)
+            if (mainWindow.TrackIRZ_ZoomFOV.IsChecked == true)
                 bs[336] = 0x01;
 
             // External Mouselook

--- a/Falcon BMS Alternative Launcher/Override/OverrideSettingFor435.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSettingFor435.cs
@@ -90,7 +90,7 @@ namespace FalconBMS.Launcher.Override
 
             // TrackIR Z-Axis(0:Z-axis 1:FOV)
             bs[336 + 48] = 0x00;
-            if (mainWindow.Misc_TrackIRZ.IsOn == true)
+            if (mainWindow.TrackIRZ_ZoomFOV.IsChecked == true)
                 bs[336 + 48] = 0x01;
 
             // External Mouselook

--- a/Falcon BMS Alternative Launcher/Override/OverrideSettingFor435.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSettingFor435.cs
@@ -90,7 +90,7 @@ namespace FalconBMS.Launcher.Override
 
             // TrackIR Z-Axis(0:Z-axis 1:FOV)
             bs[336 + 48] = 0x00;
-            if (mainWindow.Misc_TrackIRZ.IsChecked == true)
+            if (mainWindow.Misc_TrackIRZ.IsOn == true)
                 bs[336 + 48] = 0x01;
 
             // External Mouselook

--- a/Falcon BMS Alternative Launcher/Override/OverrideSettingFor437.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSettingFor437.cs
@@ -167,7 +167,7 @@ namespace FalconBMS.Launcher.Override
 
             // TrackIR Z-Axis(0:Z-axis 1:FOV)
             bs[336 + 48] = 0x00;
-            if (mainWindow.Misc_TrackIRZ.IsOn == true)
+            if (mainWindow.TrackIRZ_ZoomFOV.IsChecked == true)
                 bs[336 + 48] = 0x01;
 
             // External Mouselook

--- a/Falcon BMS Alternative Launcher/Override/OverrideSettingFor437.cs
+++ b/Falcon BMS Alternative Launcher/Override/OverrideSettingFor437.cs
@@ -167,7 +167,7 @@ namespace FalconBMS.Launcher.Override
 
             // TrackIR Z-Axis(0:Z-axis 1:FOV)
             bs[336 + 48] = 0x00;
-            if (mainWindow.Misc_TrackIRZ.IsChecked == true)
+            if (mainWindow.Misc_TrackIRZ.IsOn == true)
                 bs[336 + 48] = 0x01;
 
             // External Mouselook

--- a/Falcon BMS Alternative Launcher/Starter/AbstractStarter.cs
+++ b/Falcon BMS Alternative Launcher/Starter/AbstractStarter.cs
@@ -25,15 +25,15 @@ namespace FalconBMS.Launcher.Starter
         public virtual string getCommandLine()
         {
             string strCmdText = "";
-            if (mainWindow.CMD_ACMI.IsChecked == true)
+            if (mainWindow.CMD_ACMI.IsOn == true)
                 strCmdText += "-acmi ";
-            if (mainWindow.CMD_WINDOW.IsChecked == true)
+            if (mainWindow.CMD_WINDOW.IsOn == true)
                 strCmdText += "-window ";
-            if (mainWindow.CMD_NOMOVIE.IsChecked == true)
+            if (mainWindow.CMD_NOMOVIE.IsOn == true)
                 strCmdText += "-nomovie ";
-            if (mainWindow.CMD_EF.IsChecked == true)
+            if (mainWindow.CMD_EF.IsOn == true)
                 strCmdText += "-ef ";
-            if (mainWindow.CMD_MONO.IsChecked == true)
+            if (mainWindow.CMD_MONO.IsOn == true)
                 strCmdText += "-mono ";
 
             if (mainWindow.VR_SteamVR.IsVisible && mainWindow.VR_SteamVR.IsChecked == true)

--- a/Falcon BMS Alternative Launcher/Styles/Styles.xaml
+++ b/Falcon BMS Alternative Launcher/Styles/Styles.xaml
@@ -1,7 +1,123 @@
 ﻿<!-- Styles/Styles.xaml -->
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro">
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!-- Reuseable foreground color brushes -->
+    <SolidColorBrush x:Key="UiForegroundBrush" Color="#80FFFFFF"/>
+    <SolidColorBrush x:Key="PanelBgBrush" Color="#7F202020"/>
+    <SolidColorBrush x:Key="AxisBarBgBrush" Color="#80202020"/>
+    <SolidColorBrush x:Key="AxisBarFgBrush" Color="#803878A8"/>
+    <SolidColorBrush x:Key="ThinBorderBrush" Color="#80FFFFFF"/>
+    <SolidColorBrush x:Key="GridSelectedBgBrush" Color="#80F0F0F0"/>
+    <SolidColorBrush x:Key="GridSelectedFgBrush" Color="#FFE0E0E0"/>
+    <SolidColorBrush x:Key="GridFocusedFgBrush" Color="#FF00F8F8"/>
+
+    <Style TargetType="DataGridDetailsPresenter">
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+    </Style>
+
+    <Style TargetType="DataGridRowHeader">
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+    </Style>
+
+    <Style TargetType="DataGridCell">
+        <Style.Triggers>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter Property="Background" Value="{StaticResource GridSelectedBgBrush}"/>
+                <Setter Property="Foreground" Value="{StaticResource GridSelectedFgBrush}"/>
+                <Setter Property="BorderThickness" Value="0"/>
+            </Trigger>
+            <Trigger Property="IsFocused" Value="True">
+                <Setter Property="Background" Value="{StaticResource GridSelectedBgBrush}"/>
+                <Setter Property="Foreground" Value="{StaticResource GridFocusedFgBrush}"/>
+                <Setter Property="BorderThickness" Value="0"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="MyDataGridStyle" TargetType="DataGridRow">
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Visibility}" Value="Hidden">
+                <Setter Property="Visibility" Value="Collapsed"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Visibility}" Value="Blue">
+                <Setter Property="Background" Value="#804080A8"/>
+                <Setter Property="Foreground" Value="{StaticResource GridSelectedFgBrush}"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Visibility}" Value="Green">
+                <Setter Property="Background" Value="#00000000"/>
+                <Setter Property="Foreground" Value="#FF00F800"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Visibility}" Value="White">
+                <Setter Property="Background" Value="#00000000"/>
+                <Setter Property="Foreground" Value="{StaticResource GridSelectedFgBrush}"/>
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <LinearGradientBrush x:Key="LauncherStripBrush" StartPoint="0.5,0" EndPoint="0.5,1">
+        <GradientStop Color="#7F151719" Offset="0"/>
+        <GradientStop Color="#3F151718" Offset="1"/>
+    </LinearGradientBrush>
+
+    <Style x:Key="LauncherStripBorder" TargetType="Border">
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="Background" Value="{StaticResource LauncherStripBrush}"/>
+    </Style>
+
+    <Style x:Key="LauncherListBox" TargetType="ListBox" BasedOn="{StaticResource {x:Type ListBox}}">
+        <Setter Property="Background" Value="#80000000"/>
+        <Setter Property="BorderBrush" Value="{StaticResource ThinBorderBrush}"/>
+        <Setter Property="Foreground" Value="{StaticResource UiForegroundBrush}"/>
+        <Setter Property="SelectionMode" Value="Single"/>
+        <Setter Property="VerticalAlignment" Value="Bottom"/>
+        <Setter Property="HorizontalAlignment" Value="Right"/>
+        <Setter Property="ItemContainerStyle">
+            <Setter.Value>
+                <Style TargetType="ListBoxItem">
+                    <Setter Property="Background" Value="Transparent"/>
+                    <Setter Property="Margin" Value="1"/>
+                </Style>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+
+    <!-- TABS -->
+    <Style x:Key="TabHeader" TargetType="TabItem"
+       BasedOn="{StaticResource {x:Type TabItem}}">
+        <Style.Triggers>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter Property="Foreground" Value="{StaticResource UiForegroundBrush}"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    <Style x:Key="SubTabHeader"
+       TargetType="TabItem"
+       BasedOn="{StaticResource {x:Type TabItem}}">
+        <Setter Property="HeaderTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <TextBlock Text="{Binding}"
+                      FontSize="24" 
+                      />
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <Style TargetType="RadioButton"
+       BasedOn="{StaticResource {x:Type RadioButton}}">
+        <Setter Property="Foreground" Value="{StaticResource UiForegroundBrush}"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="BorderBrush" Value="Transparent"/>
+    </Style>
 
     <!-- LAUNCHER tab -->
     <Style x:Key="LauncherHeading" TargetType="Label">
@@ -10,23 +126,23 @@
         <Setter Property="FontSize" Value="24"/>
         <Setter Property="FontWeight" Value="Bold"/>
         <Setter Property="FontStyle" Value="Italic"/>
-        <Setter Property="Foreground" Value="#80FFFFFF" />
+        <Setter Property="Foreground" Value="LightBlue" />
     </Style>
     <Style x:Key="LauncherTitle" TargetType="Label">
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="FontWeight" Value="Bold" />
-        <Setter Property="Foreground" Value="#80FFFFFF" />
+        <Setter Property="Foreground" Value="{StaticResource UiForegroundBrush}"/>
     </Style>
-    <Style x:Key="LauncherToggleSwitch"
-           TargetType="Controls:ToggleSwitch"
-           BasedOn="{StaticResource {x:Type Controls:ToggleSwitch}}">
+    <Style x:Key="LauncherToggleSwitch" TargetType="Controls:ToggleSwitch" BasedOn="{StaticResource {x:Type Controls:ToggleSwitch}}">
         <Setter Property="FontSize" Value="11"/>
         <Setter Property="HorizontalAlignment" Value="Left"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
         <Setter Property="VerticalAlignment" Value="Top"/>
         <Setter Property="Foreground" Value="#80FFFFFF" />
     </Style>
+
+
     <Style x:Key="LauncherRadioButton" 
            TargetType="RadioButton"
            BasedOn="{StaticResource {x:Type RadioButton}}">
@@ -40,7 +156,7 @@
         <Setter Property="FontSize" Value="16"/>
         <Setter Property="FontWeight" Value="Bold"/>
         <Setter Property="FontStyle" Value="Oblique"/>
-        <Setter Property="Foreground" Value="#80FFFFFF"/>
+        <Setter Property="Foreground" Value="{StaticResource UiForegroundBrush}"/>
         <Setter Property="HorizontalAlignment" Value="Left"/>
         <Setter Property="VerticalAlignment" Value="Top"/>
         <Setter Property="Height" Value="41"/>
@@ -50,11 +166,21 @@
            BasedOn="{StaticResource {x:Type Label}}">
         <Setter Property="FontSize" Value="16"/>
         <Setter Property="FontWeight" Value="Bold"/>
-        <Setter Property="Foreground" Value="#80FFFFFF"/>
+        <Setter Property="Foreground" Value="{StaticResource UiForegroundBrush}"/>
         <Setter Property="HorizontalAlignment" Value="Left"/>
         <Setter Property="VerticalAlignment" Value="Top"/>
         <Setter Property="Height" Value="34"/>
         <Setter Property="Width" Value="150"/>
+    </Style>
+    <Style x:Key="AxisLabel" TargetType="Label"
+           BasedOn="{StaticResource {x:Type Label}}">
+        <Setter Property="HorizontalContentAlignment" Value="Right"/>
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="VerticalAlignment" Value="Top"/>
+        <Setter Property="FontSize" Value="16"/>
+        <Setter Property="Foreground" Value="{StaticResource UiForegroundBrush}" />
+        <Setter Property="Height" Value="34"/>
+        <Setter Property="Width" Value="100"/>
     </Style>
     <Style x:Key="AssignButtonBase"
        TargetType="Button"
@@ -78,11 +204,26 @@
         <Setter Property="Height" Value="10"/>
         <Setter Property="HorizontalAlignment" Value="Left"/>
         <Setter Property="VerticalAlignment" Value="Top"/>
-        <Setter Property="Background" Value="#80202020"/>
-        <Setter Property="Foreground" Value="#803878A8"/>
-        <Setter Property="BorderBrush" Value="#80FFFFFF"/>
+        <Setter Property="Background" Value="{StaticResource AxisBarBgBrush}"/>
+        <Setter Property="Foreground" Value="{StaticResource AxisBarFgBrush}"/>
+        <Setter Property="BorderBrush" Value="{StaticResource ThinBorderBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
     </Style>
-
-
+    <Style x:Key="HelpText"
+       TargetType="TextBlock">
+        <Setter Property="Foreground" Value="{StaticResource UiForegroundBrush}" />
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+        <Setter Property="VerticalAlignment" Value="Top"/>
+    </Style>
+    <Style TargetType="CheckBox" BasedOn="{StaticResource {x:Type CheckBox}}">
+        <Setter Property="Foreground" Value="{StaticResource UiForegroundBrush}"/>
+        <Style.Resources>
+            <DataTemplate DataType="{x:Type sys:String}">
+                <TextBlock Text="{Binding}"
+                   Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=CheckBox}}"/>
+            </DataTemplate>
+        </Style.Resources>
+    </Style>
+    
 </ResourceDictionary>

--- a/Falcon BMS Alternative Launcher/Windows/KeyMappingWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/KeyMappingWindow.xaml
@@ -43,8 +43,8 @@
         <Border BorderBrush="#D0191919" BorderThickness="1" HorizontalAlignment="Center" Height="28" Margin="32,67,33,0" VerticalAlignment="Top" Width="447"/>
         <Button x:Name="ClearDX" Content="Clear DX" HorizontalAlignment="Left" Margin="404,112,0,0" VerticalAlignment="Top" Width="75" Click="ClearDX_Click"/>
         <Button x:Name="ClearKey" Content="Clear Key" HorizontalAlignment="Left" Margin="404,144,0,0" VerticalAlignment="Top" Width="75" Click="ClearKey_Click"/>
-        <Controls:ToggleSwitch x:Name="Select_PinkyShift" OnLabel="SHIFTED" OffLabel="Unshifted" HorizontalAlignment="Right" Margin="0,112,320,0" VerticalAlignment="Top" Width="160" Height="27" />
-        <Controls:ToggleSwitch x:Name="Select_DX_Release" OnLabel="ON RELEASE" OffLabel="On Press" HorizontalAlignment="Right" Margin="0,144,320,0" VerticalAlignment="Top" Width="160"  Height="27"/>
+        <Controls:ToggleSwitch x:Name="Select_PinkyShift" OnContent="SHIFTED" OffContent="Unshifted" HorizontalAlignment="Right" Margin="0,112,320,0" VerticalAlignment="Top" Width="160" Height="27" />
+        <Controls:ToggleSwitch x:Name="Select_DX_Release" OnContent="ON RELEASE" OffContent="On Press" HorizontalAlignment="Right" Margin="0,144,320,0" VerticalAlignment="Top" Width="160"  Height="27"/>
         <Button x:Name="Save" Content="Save" HorizontalAlignment="Left" Margin="404,176,0,0" VerticalAlignment="Top" Width="75" Click="Save_Click"/>
         <TextBlock TextWrapping="Wrap" Margin="32,46,33,174" FontSize="9"><Run Text="* Alternative Launcher only saves POV hat bindings for the Roll and/or Throttle devices"/></TextBlock>
         <TextBlock x:Name="CurrentlyMapped" Width="200" Height="45" TextWrapping="WrapWithOverflow" Margin="197,126,113,65" FontSize="10" FontWeight="Bold" Foreground="DarkRed"><Run Text="Input currently bound to Xxxxx"/></TextBlock>

--- a/Falcon BMS Alternative Launcher/Windows/KeyMappingWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/KeyMappingWindow.xaml.cs
@@ -145,7 +145,7 @@ namespace FalconBMS.Launcher.Windows
             string currCallback0 = tmpjoy.dx[buttonId].assign[0].GetCallback();
             if (currCallback0 == "SimHotasPinkyShift" || currCallback0 == "SimHotasShift")
             {
-                this.Select_PinkyShift.IsChecked = newState;
+                this.Select_PinkyShift.IsOn = newState;
                 return;
             }
 
@@ -154,9 +154,9 @@ namespace FalconBMS.Launcher.Windows
                 return;
 
             // Show UI feedback, and currently mapped callback, if any -- incl consideration for shift- and release-modes.
-            Pinky pinky = (this.Select_PinkyShift.IsChecked == true ? Pinky.Shift : Pinky.UnShift);
-            Behaviour behaviour = (this.Select_DX_Release.IsChecked == true ? Behaviour.Release : Behaviour.Press);
-            Invoke action = (this.Select_DX_Release.IsChecked == true ? Invoke.Down : Invoke.Default);
+            Pinky pinky = (this.Select_PinkyShift.IsOn == true ? Pinky.Shift : Pinky.UnShift);
+            Behaviour behaviour = (this.Select_DX_Release.IsOn == true ? Behaviour.Release : Behaviour.Press);
+            Invoke action = (this.Select_DX_Release.IsOn == true ? Invoke.Down : Invoke.Default);
 
             int mappingBehavior = (int)pinky + (int)behaviour;
             string currCallback = tmpjoy.dx[buttonId].assign[mappingBehavior].GetCallback();
@@ -172,7 +172,7 @@ namespace FalconBMS.Launcher.Windows
                 KeyAssgn row = _keyFile.LookupCallback(currCallback);
                 string currCallbackDescr = row != null ? row.GetKeyDescription() : currCallback;
 
-                string pressOrRelease = (this.Select_DX_Release.IsChecked == true) ? "release" : "press";
+                string pressOrRelease = (this.Select_DX_Release.IsOn == true) ? "release" : "press";
                 this.CurrentlyMapped.Text = $"Button {pressOrRelease} currently bound to:\r\n" + currCallbackDescr;
                 this.CurrentlyMapped.Visibility = Visibility.Visible;
             }
@@ -197,7 +197,7 @@ namespace FalconBMS.Launcher.Windows
             if (newDirection < 0) return;
 
             // Show UI feedback, and currently mapped callback, if any -- incl support for dx-shift mappings.
-            Pinky pinky = (this.Select_PinkyShift.IsChecked == true ? Pinky.Shift : Pinky.UnShift);
+            Pinky pinky = (this.Select_PinkyShift.IsOn == true ? Pinky.Shift : Pinky.UnShift);
 
             string currCallback = tmpjoy.pov[povhatId].GetCurrentCallback(newDirection, pinky);
 
@@ -280,7 +280,7 @@ namespace FalconBMS.Launcher.Windows
             if ((Microsoft.DirectX.DirectInput.Key)catchedScanCode == Microsoft.DirectX.DirectInput.Key.Y && !Shift && !Ctrl && !Alt)
                 return;
 
-            Pinky pinkyStatus = (Select_PinkyShift.IsChecked == true) ? Pinky.Shift : Pinky.UnShift;
+            Pinky pinkyStatus = (Select_PinkyShift.IsOn == true) ? Pinky.Shift : Pinky.UnShift;
 
             // Determine if this input is already mapped to another callback, and display warning/hint if so.
             KeyAssgn currCallbackAssgn = _keyFile.ReverseLookupKeyboardInput(catchedScanCode, Shift, Ctrl, Alt);

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -484,13 +484,15 @@
                                     <Label x:Name="Label_Camera_Distance" Margin="188,100,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Camera_Distance" Margin="32,134,0,0" Width="256" Height="10" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="Camera_Distance" Margin="320,126,0,0" Style="{StaticResource AssignButton}"/>
-                                    <Controls:ToggleSwitch x:Name="Misc_TrackIRZ" OnContent="TrackIR Zoom Fov" OffContent="TrackIR Head Forward" Margin="228,10,0,0" Style="{StaticResource LauncherToggleSwitch}"/>
-                                    <CheckBox x:Name="Misc_ExMouseLook" Content="External MouseLook" HorizontalAlignment="Left" Margin="32,192,0,0" VerticalAlignment="Top" />
-                                    <TextBlock Text="Allows the mouse to control the camera for external views. Note that if this is enabled, controlling the external camera with the POV hat will be disabled." Margin="56,215,0,82" Style="{StaticResource HelpText}"/>
-                                    <CheckBox x:Name="Misc_NaturalHeadMovement" Content="Natural Head Movement" HorizontalAlignment="Left" Margin="32,258,0,0" VerticalAlignment="Top" />
-                                    <TextBlock Text="Using this option will provide a more realistic experience when looking back at your six o'clock position as it will take into account the torso movement necessary to do so (valid with and without TIR)." TextWrapping="Wrap" Margin="56,281,0,-4" Style="{StaticResource HelpText}"/>
-                                    <CheckBox x:Name="Misc_PilotModel" Content="Pilot Model" HorizontalAlignment="Left" Margin="32,338,0,0" VerticalAlignment="Top"  Height="17"/>
-                                    <TextBlock Margin="56,359,0,-61" Style="{StaticResource HelpText}">
+                                    <RadioButton x:Name="TrackIRZ_HeadForward" GroupName="TrackIRZ" Content="TrackIR Head Forward" Margin="183,19,0,0" Style="{StaticResource LauncherRadioButton}"/>
+                                    <RadioButton x:Name="TrackIRZ_ZoomFOV" GroupName="TrackIRZ" Content="TrackIR Zoom FOV" Margin="349,19,0,0" Style="{StaticResource LauncherRadioButton}"/>
+
+                                    <CheckBox x:Name="Misc_ExMouseLook" Content="External MouseLook" HorizontalAlignment="Left" Margin="32,193,0,0" VerticalAlignment="Top" />
+                                    <TextBlock Text="Allows the mouse to control the camera for external views. Note that if this is enabled, controlling the external camera with the POV hat will be disabled." Margin="56,216,0,0" Style="{StaticResource HelpText}"/>
+                                    <CheckBox x:Name="Misc_NaturalHeadMovement" Content="Natural Head Movement" HorizontalAlignment="Left" Margin="32,260,0,0" VerticalAlignment="Top" />
+                                    <TextBlock Text="Using this option will provide a more realistic experience when looking back at your six o'clock position as it will take into account the torso movement necessary to do so (valid with and without TIR)." TextWrapping="Wrap" Margin="56,283,0,0" Style="{StaticResource HelpText}"/>
+                                    <CheckBox x:Name="Misc_PilotModel" Content="Pilot Model" HorizontalAlignment="Left" Margin="32,340,0,0" VerticalAlignment="Top"  Height="17"/>
+                                    <TextBlock Margin="56,361,0,0" Style="{StaticResource HelpText}">
                                         <Run Text="Shows Pilot Model in 3D cockpit with kneeboards. "/>
                                         <Hyperlink NavigateUri="http://www.weapondeliveryplanner.nl/" RequestNavigate="WDP_RequestNavigate" Foreground="#FF6CD2FF">
                                             Weapon Delivery Planner

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -227,7 +227,7 @@
                         <Label Content="Theater :" Style="{StaticResource LauncherTitle}"/>
                         <ComboBox x:Name="Dropdown_TheaterList" Background="#80F0F0F0" Foreground="#FF191919" HorizontalAlignment="Left" Margin="180,4,0,0" VerticalAlignment="Top" Width="239" SelectionChanged="Dropdown_TheaterList_SelectionChanged"/>
 
-                        <Button x:Name="Launch_TheaterConfig" Content="Theater Config" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" Controls:ControlsHelper.ContentCharacterCasing="Normal" Margin="424,2,429,0" VerticalAlignment="Top" Click="Launch_TheaterConfig_Click" FontSize="10" RenderTransformOrigin="-0.033,0.5"/>
+                        <Button x:Name="Launch_TheaterConfig" Content="Theater Config" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" Controls:ControlsHelper.ContentCharacterCasing="Normal" Margin="424,4,429,0" VerticalAlignment="Top" Click="Launch_TheaterConfig_Click" FontSize="10" RenderTransformOrigin="-0.033,0.5"/>
 
                         <Label Content="Command Line :" Margin="0,96,0,-27" Style="{StaticResource LauncherTitle}"/>
 
@@ -240,8 +240,8 @@
                         <RadioButton x:Name="RTT_Disable" GroupName="RTT" Content="Disable" Margin="660,69,0,0" Style="{StaticResource LauncherRadioButton}"/>
                         <RadioButton x:Name="RTT_Enable" GroupName="RTT" Content="Enable" Margin="730,69,0,0" Style="{StaticResource LauncherRadioButton}"/>
 
-                        <Label Content="Documentation and Manuals :" Margin="0,32,0,0" Style="{StaticResource LauncherTitle}"/>
-                        <Button x:Name="OpenDocs" Content="Open Docs Folder" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" Controls:ControlsHelper.ContentCharacterCasing="Normal" HorizontalAlignment="Left" Margin="179,34,0,0" VerticalAlignment="Top" Width="141" Click="OpenDocs_Click" FontSize="10" Height="10"/>
+                        <Label Content="Documentation and Manuals :" Margin="0,35,0,0" Style="{StaticResource LauncherTitle}"/>
+                        <Button x:Name="OpenDocs" Content="Open Docs Folder" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" Controls:ControlsHelper.ContentCharacterCasing="Normal" HorizontalAlignment="Left" Margin="180,37,0,0" VerticalAlignment="Top" Width="141" Click="OpenDocs_Click" FontSize="10" Height="10"/>
 
                         <Controls:ToggleSwitch x:Name="CMD_ACMI" OnContent="ACMI On" OffContent="ACMI Off" Margin="178,94,0,0" Style="{StaticResource LauncherToggleSwitch}"/>
                         <Controls:ToggleSwitch x:Name="CMD_WINDOW" OnContent="WINDOW On" OffContent="WINDOW Off" Margin="313,94,0,0" Toggled="CMD_WINDOW_Click" Style="{StaticResource LauncherToggleSwitch}"/>
@@ -373,11 +373,11 @@
                                 </Grid>
                                 <TextBlock Margin="102,355,0,0" Height="55" Width="378" Style="{StaticResource HelpText}"><Run Text="&quot;Throttle&quot; works as "/><Run Text="&quot;"/><Run Text="Both Throttle"/><Run Text="&quot;"/><Run Text=" "/><Run Text="for twin engine jets"/><Run Text=" "/><Run Text="as long as no axis are applied to &quot;Throttle Right"/><Run Text="&quot; "/><Run Text="or it "/><Run Text="will work as &quot;Throttle Left&quot;"/><LineBreak/><Run Text="For F-16 &quot;Throttle&quot; works as a main engine."/><LineBreak/></TextBlock>
                                 <CheckBox x:Name="Misc_RollLinkedNWS"
-          Foreground="White"
-          Content="Use Roll Axis for Steering while on the Ground enabling NWS."
-          HorizontalAlignment="Left" Margin="512,533,0,0" VerticalAlignment="Top"
-          Height="18" Width="349"/>
-                                <Label Content="*Enabling this option disables Yaw axis." FontSize="11" HorizontalAlignment="Left" Margin="530,550,0,0" VerticalAlignment="Top" Height="25" Width="273"/>
+                                     Foreground="{StaticResource UiForegroundBrush}"
+                                     Content="Use Roll Axis for Steering while on the Ground enabling NWS."
+                                     HorizontalAlignment="Left" Margin="512,533,0,0" VerticalAlignment="Top"
+                                     Height="18" Width="349"/>
+                                <Label Content="*Enabling this option disables Yaw axis." FontSize="11" HorizontalAlignment="Left" Margin="530,550,0,0" VerticalAlignment="Top" Height="25" Width="273" Foreground="{StaticResource UiForegroundBrush}"/>
                                 <TextBlock Margin="32,574,0,0" Height="36" Width="378" Style="{StaticResource HelpText}"><Run Text="&quot;Toe Brake&quot; works as &quot;"/><Run Text="Both Toe Brakes"/><Run Text="&quot;"/><Run Text=" "/><Run Text="as long as no axis are applied to &quot;Toe Brake Right"/><Run Text="&quot; "/><Run Text="or it "/><Run Text="will work as &quot;Throttle Left&quot; &quot;Toe Brake Left&quot;"/><LineBreak/></TextBlock>
                                 <TextBlock Margin="32,145,0,0" Height="35" Width="378" Style="{StaticResource HelpText}"><Run Text="FalconBMS implements real F-16 FLCS curve. "/><LineBreak/><Run Text="Disable any Deadzone and Saturation/Curve recommended"/></TextBlock>
                             </Grid>

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -225,7 +225,7 @@
                     <Grid HorizontalAlignment="Left" Height="127" Margin="46,0,0,191.333" VerticalAlignment="Bottom" Width="953">
 
                         <Label Content="Theater :" Style="{StaticResource LauncherTitle}"/>
-                        <ComboBox x:Name="Dropdown_TheaterList" Background="#80F0F0F0" Foreground="#FF191919" HorizontalAlignment="Left" Margin="180,4,0,0" VerticalAlignment="Top" Width="239" SelectionChanged="Dropdown_TheaterList_SelectionChanged"/>
+                        <ComboBox x:Name="Dropdown_TheaterList" Background="#F0F0F0" Foreground="#FF191919" HorizontalAlignment="Left" Margin="180,4,0,0" VerticalAlignment="Top" Width="239" SelectionChanged="Dropdown_TheaterList_SelectionChanged"/>
 
                         <Button x:Name="Launch_TheaterConfig" Content="Theater Config" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" Controls:ControlsHelper.ContentCharacterCasing="Normal" Margin="424,4,429,0" VerticalAlignment="Top" Click="Launch_TheaterConfig_Click" FontSize="10" RenderTransformOrigin="-0.033,0.5"/>
 
@@ -477,12 +477,12 @@
 
                                     <Label Content="FOV : " Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_FOV" Margin="188,51,0,0" Style="{StaticResource AxisLabel}"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_FOV" HorizontalAlignment="Left" Margin="32,85,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_FOV" Margin="32,85,0,0" Width="256" Height="10" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="FOV" Margin="320,77,0,0" Style="{StaticResource AssignButton}" RenderTransformOrigin="0.216,1.519"/>
 
                                     <Label Content="Distance :" Margin="32,100,0,0" Style="{StaticResource AxisTitle}"/>
                                     <Label x:Name="Label_Camera_Distance" Margin="188,100,0,0" Style="{StaticResource AxisLabel}"/>
-                                    <Controls:MetroProgressBar x:Name="Axis_Camera_Distance" HorizontalAlignment="Left" Margin="32,134,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
+                                    <Controls:MetroProgressBar x:Name="Axis_Camera_Distance" Margin="32,134,0,0" Width="256" Height="10" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="Camera_Distance" Margin="320,126,0,0" Style="{StaticResource AssignButton}"/>
                                     <Controls:ToggleSwitch x:Name="Misc_TrackIRZ" OnContent="TrackIR Zoom Fov" OffContent="TrackIR Head Forward" Margin="228,10,0,0" Style="{StaticResource LauncherToggleSwitch}"/>
                                     <CheckBox x:Name="Misc_ExMouseLook" Content="External MouseLook" HorizontalAlignment="Left" Margin="32,192,0,0" VerticalAlignment="Top" />

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:wfc="clr-namespace:System.Windows.Forms.DataVisualization.Charting;assembly=System.Windows.Forms.DataVisualization"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
+        xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"              
         mc:Ignorable="d"
         Title="FalconBMS Alternative Launcher" Height="768" Width="1024" MinHeight="768" MinWidth="1024" BorderThickness="0"
         Closed="Window_Closed" MouseDown="MetroWindow_MouseDown"
@@ -14,73 +14,8 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/Styles/Styles.xaml"/>
             </ResourceDictionary.MergedDictionaries>
-
-        <Style TargetType="Label">
-            <Setter Property="Foreground" Value="#80FFFFFF" />
-        </Style>
-        <Style TargetType="CheckBox">
-            <Setter Property="Foreground" Value="#80FFFFFF" />
-        </Style>
-        <Style TargetType="ComboBox">
-            <Setter Property="Foreground" Value="#80FFFFFF" />
-        </Style>
-        <Style TargetType="Controls:ToggleSwitch">
-            <Setter Property="Foreground" Value="#80FFFFFF" />
-        </Style>
-        <Style TargetType="TextBlock">
-            <Setter Property="Foreground" Value="#80FFFFFF" />
-        </Style>
-        <Style TargetType="Controls:MetroProgressBar">
-            <Setter Property="Background" Value="#80202020" />
-            <Setter Property="Foreground" Value="#803878A8" />
-            <Setter Property="BorderBrush" Value="#80FFFFFF" />
-            <Setter Property="BorderThickness" Value="1" />
-        </Style>
-        <Style TargetType="DataGridDetailsPresenter">
-            <Setter Property="HorizontalAlignment" Value="Left"/>
-            <Setter Property="VerticalAlignment" Value="Center"/>
-        </Style>
-        <Style TargetType="DataGridRowHeader">
-            <Setter Property="HorizontalAlignment" Value="Left"/>
-            <Setter Property="VerticalAlignment" Value="Center"/>
-            <Setter Property="HorizontalContentAlignment" Value="Left"/>
-            <Setter Property="VerticalContentAlignment" Value="Center"/>
-        </Style>
-        <Style TargetType="DataGridCell">
-            <Style.Triggers>
-                <Trigger Property="IsSelected" Value="True">
-                    <Setter Property="Background" Value="#80F0F0F0" />
-                    <Setter Property="Foreground" Value="#FFE0E0E0" />
-                    <Setter Property="BorderThickness" Value="0" />
-                </Trigger>
-                <Trigger Property="IsFocused" Value="True">
-                    <Setter Property="Background" Value="#80F0F0F0" />
-                    <Setter Property="Foreground" Value="#FF00F8F8" />
-                    <Setter Property="BorderThickness" Value="0" />
-                </Trigger>
-            </Style.Triggers>
-        </Style>
-        <Style x:Key="MyDataGridStyle" TargetType="DataGridRow">
-            <Style.Triggers>
-                <DataTrigger Binding="{Binding Visibility}" Value="Hidden">
-                    <Setter Property="Visibility" Value="Collapsed"/>
-                </DataTrigger>
-                <DataTrigger Binding="{Binding Visibility}" Value="Blue">
-                    <Setter Property="Background" Value="#804080A8"/>
-                    <Setter Property="Foreground" Value="#FFE0E0E0"/>
-                </DataTrigger>
-                <DataTrigger Binding="{Binding Visibility}" Value="Green">
-                    <Setter Property="Background" Value="#00000000"/>
-                    <Setter Property="Foreground" Value="#FF00F800"/>
-                </DataTrigger>
-                <DataTrigger Binding="{Binding Visibility}" Value="White">
-                    <Setter Property="Background" Value="#00000000"/>
-                    <Setter Property="Foreground" Value="#FFE0E0E0"/>
-                </DataTrigger>
-            </Style.Triggers>
-        </Style>
-         </ResourceDictionary>
-        </Window.Resources>
+        </ResourceDictionary>
+    </Window.Resources>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="651*"/>
@@ -114,15 +49,9 @@
             <Grid HorizontalAlignment="Stretch" Height="auto" Margin="0,0,0,0" VerticalAlignment="Stretch" Width="auto"/>
         </Border>
         <TabControl x:Name="LargeTab" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" SelectionChanged="TabControl_SelectionChanged" Margin="0,64,0.333,0.334" Background="{x:Null}" Grid.RowSpan="2">
-            <TabItem Header="LAUNCHER" x:Name="Tab_Launcher" HorizontalAlignment="Center" Margin="535,-40,-535.333,40.333">
+            <TabItem Header="LAUNCHER" x:Name="Tab_Launcher" Margin="535,-40,-535.333,40.333" Style="{StaticResource TabHeader}">
                 <Grid>
-                    <Border BorderThickness="1" HorizontalAlignment="Left" Height="72" Width="638" Margin="48,0,0,97" VerticalAlignment="Bottom">
-                        <Border.Background>
-                            <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
-                                <GradientStop Color="#7F151719" Offset="0"/>
-                                <GradientStop Color="#3F151718" Offset="1"/>
-                            </LinearGradientBrush>
-                        </Border.Background>
+                    <Border BorderThickness="1" HorizontalAlignment="Left" Height="72" Width="638" Margin="48,0,0,97" VerticalAlignment="Bottom" Style="{StaticResource LauncherStripBorder}">
                         <Grid HorizontalAlignment="Stretch" Height="auto" Margin="0,0,0,0" VerticalAlignment="Stretch" Width="auto">
                             <Grid.Resources>
                                 <Style TargetType="Button">
@@ -220,16 +149,10 @@
                             <Label x:Name="Label_EDIT" Content="Editor&#xD;&#xA;" Margin="575,0,0,0"/>
                         </Grid>
                     </Border>
-                    <CheckBox x:Name="ApplicationOverride" Content="Launch without any setup override" HorizontalAlignment="Right" Margin="0,0,14.667,97.667" VerticalAlignment="Bottom" Background="#FFECFF71" />
+                    <CheckBox x:Name="ApplicationOverride" Content="Launch without any setup override" HorizontalAlignment="Right" Margin="0,0,14.667,97.667" VerticalAlignment="Bottom" Background="#FFECFF71" Foreground="{StaticResource UiForegroundBrush}" />
 
 
-                    <Border BorderThickness="1" HorizontalAlignment="Left" Height="72" Margin="48,0,0,20.333" VerticalAlignment="Bottom" Width="503">
-                        <Border.Background>
-                            <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
-                                <GradientStop Color="#7F151719" Offset="0"/>
-                                <GradientStop Color="#3F151718" Offset="1"/>
-                            </LinearGradientBrush>
-                        </Border.Background>
+                    <Border BorderThickness="1" HorizontalAlignment="Left" Height="72" Margin="48,0,0,20.333" VerticalAlignment="Bottom" Width="503" Style="{StaticResource LauncherStripBorder}">
                         <Grid HorizontalAlignment="Stretch" Height="auto" Margin="0,0,0,0" VerticalAlignment="Stretch" Width="auto">
                             <Grid.Resources>
                                 <Style TargetType="Button">
@@ -296,21 +219,15 @@
                             <Label x:Name="Label_F4RADAR" Content="     F4 RADAR&#xA;C2(AWACS) Tool" Margin="281,0,0,0.333"/>
                         </Grid>
                     </Border>
-                    <Button x:Name="Launch_BMS_Large" Content="LAUNCH" Style="{StaticResource AccentedSquareButtonStyle}" Controls:ControlsHelper.ContentCharacterCasing="Normal" HorizontalAlignment="Right" Margin="0,0,9.667,20.333" VerticalAlignment="Bottom" Width="208" Click="Launch_Click" Height="72" Background="#CC2494FF" BorderBrush="{x:Null}" FontSize="24" Grid.Row="1"/>
-                    <ListBox x:Name="ListBox_BMS" SelectionChanged="ListBox_BMS_SelectionChanged"  HorizontalAlignment="Right" Height="72" Margin="0,0,222.667,20.333" VerticalAlignment="Bottom" Width="217" Background="#80000000" BorderBrush="#80FFFFFF" Foreground="#80FFFFFF" SelectionMode="Single">
-                        <ListBox.Resources>
-                            <Style TargetType="{x:Type ListBoxItem}">
-                                <Setter Property="Background" Value="Transparent" />
-                                <Setter Property="Margin" Value="1" />
-                            </Style>
-                        </ListBox.Resources>
+                    <Button x:Name="Launch_BMS_Large" Content="LAUNCH" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" Controls:ControlsHelper.ContentCharacterCasing="Normal" HorizontalAlignment="Right" Margin="0,0,9.667,20.333" VerticalAlignment="Bottom" Width="208" Click="Launch_Click" Height="72" Background="#CC2494FF" BorderBrush="{x:Null}" FontSize="24" Grid.Row="1"/>
+                    <ListBox x:Name="ListBox_BMS" SelectionChanged="ListBox_BMS_SelectionChanged" Height="72" Margin="0,0,222.667,20.333" Width="217" Style="{StaticResource LauncherListBox}">
                     </ListBox>
                     <Grid HorizontalAlignment="Left" Height="127" Margin="46,0,0,191.333" VerticalAlignment="Bottom" Width="953">
 
                         <Label Content="Theater :" Style="{StaticResource LauncherTitle}"/>
                         <ComboBox x:Name="Dropdown_TheaterList" Background="#80F0F0F0" Foreground="#FF191919" HorizontalAlignment="Left" Margin="180,4,0,0" VerticalAlignment="Top" Width="239" SelectionChanged="Dropdown_TheaterList_SelectionChanged"/>
 
-                        <Button x:Name="Launch_TheaterConfig" Content="Theater Config" Style="{StaticResource AccentedSquareButtonStyle}" Controls:ControlsHelper.ContentCharacterCasing="Normal" Margin="424,2,429,0" VerticalAlignment="Top" Click="Launch_TheaterConfig_Click" FontSize="10" RenderTransformOrigin="-0.033,0.5"/>
+                        <Button x:Name="Launch_TheaterConfig" Content="Theater Config" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" Controls:ControlsHelper.ContentCharacterCasing="Normal" Margin="424,2,429,0" VerticalAlignment="Top" Click="Launch_TheaterConfig_Click" FontSize="10" RenderTransformOrigin="-0.033,0.5"/>
 
                         <Label Content="Command Line :" Margin="0,96,0,-27" Style="{StaticResource LauncherTitle}"/>
 
@@ -324,17 +241,16 @@
                         <RadioButton x:Name="RTT_Enable" GroupName="RTT" Content="Enable" Margin="730,69,0,0" Style="{StaticResource LauncherRadioButton}"/>
 
                         <Label Content="Documentation and Manuals :" Margin="0,32,0,0" Style="{StaticResource LauncherTitle}"/>
-                        <Button x:Name="OpenDocs" Content="Open Docs Folder" Style="{StaticResource AccentedSquareButtonStyle}" Controls:ControlsHelper.ContentCharacterCasing="Normal" HorizontalAlignment="Left" Margin="179,34,0,0" VerticalAlignment="Top" Width="141" Click="OpenDocs_Click" FontSize="10" Height="10"/>
+                        <Button x:Name="OpenDocs" Content="Open Docs Folder" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" Controls:ControlsHelper.ContentCharacterCasing="Normal" HorizontalAlignment="Left" Margin="179,34,0,0" VerticalAlignment="Top" Width="141" Click="OpenDocs_Click" FontSize="10" Height="10"/>
 
-                        <Controls:ToggleSwitch x:Name="CMD_ACMI" OnLabel="ACMI On" OffLabel="ACMI Off" Margin="178,94,0,0" Style="{StaticResource LauncherToggleSwitch}"/>
+                        <Controls:ToggleSwitch x:Name="CMD_ACMI" OnContent="ACMI On" OffContent="ACMI Off" Margin="178,94,0,0" Style="{StaticResource LauncherToggleSwitch}"/>
+                        <Controls:ToggleSwitch x:Name="CMD_WINDOW" OnContent="WINDOW On" OffContent="WINDOW Off" Margin="313,94,0,0" Toggled="CMD_WINDOW_Click" Style="{StaticResource LauncherToggleSwitch}"/>
+                        <Controls:ToggleSwitch x:Name="CMD_NOMOVIE" OnContent="NOMOVIE On" OffContent="NOMOVIE Off" Margin="472,94,0,0" Style="{StaticResource LauncherToggleSwitch}"/>
+                        <Controls:ToggleSwitch x:Name="CMD_EF" OnContent="EYEFLY On" OffContent="EYEFLY Off" Margin="633,94,0,0" Style="{StaticResource LauncherToggleSwitch}"/>
+                        <Controls:ToggleSwitch x:Name="CMD_MONO" OnContent="DEBUG On" OffContent="DEBUG Off" Margin="776,94,0,0" Style="{StaticResource LauncherToggleSwitch}"/>
 
-                        <Controls:ToggleSwitch x:Name="CMD_WINDOW" OnLabel="WINDOW On" OffLabel="WINDOW Off" Margin="313,94,0,0" Click="CMD_WINDOW_Click" Style="{StaticResource LauncherToggleSwitch}"/>
-                        <Controls:ToggleSwitch x:Name="CMD_NOMOVIE" OnLabel="NOMOVIE On" OffLabel="NOMOVIE Off" Margin="472,94,0,0" Style="{StaticResource LauncherToggleSwitch}"/>
-                        <Controls:ToggleSwitch x:Name="CMD_EF" OnLabel="EYEFLY On" OffLabel="EYEFLY Off" Margin="633,94,0,0" Style="{StaticResource LauncherToggleSwitch}"/>
-                        <Controls:ToggleSwitch x:Name="CMD_MONO" OnLabel="DEBUG On" OffLabel="DEBUG Off" Margin="776,94,0,0" Style="{StaticResource LauncherToggleSwitch}"/>
-                        
                         <Button x:Name="CMD_BW" Content="BW : 1024" HorizontalAlignment="Left" Margin="881,66,0,0" VerticalAlignment="Top" Width="64" Click="CMD_BW_Click"/>
-                        <Controls:ToggleSwitch x:Name="AB_Test" Visibility="Hidden" OffLabel="A" OnLabel="B" Margin="700,10,10,10" HorizontalAlignment="Left" VerticalAlignment="Top" Width="85" Height="36" />
+                        <Controls:ToggleSwitch x:Name="AB_Test" Visibility="Hidden" OffContent="A" OnContent="B" Margin="700,10,10,10" HorizontalAlignment="Left" VerticalAlignment="Top" Width="85" Height="36" />
                     </Grid>
                     <ScrollViewer x:Name ="LogTextScroll" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Margin="48,57,563.667,349.333" Background="#54000000">
                         <TextBlock x:Name="News" HorizontalAlignment="Left" TextWrapping="Wrap" Text="" VerticalAlignment="Top" Height="Auto" Width="350" Margin="20,20,0,0" />
@@ -342,7 +258,7 @@
                     <Label Content="News" Margin="48,10,0,0" Style="{StaticResource LauncherHeading}"/>
                 </Grid>
             </TabItem>
-            <TabItem Header="AXISASSIGN" Margin="535.333,-40,-535,40.333">
+            <TabItem Header="AXISASSIGN" Margin="535.333,-40,-535,40.333" Style="{StaticResource TabHeader}">
                 <Grid>
                     <Grid.Resources>
                         <Style x:Key="AssignButton"
@@ -352,19 +268,19 @@
                         </Style>
                     </Grid.Resources>
                     <TabControl HorizontalAlignment="Stretch" Height="Auto" VerticalAlignment="Stretch" Width="auto" Margin="10,0" Background="{x:Null}">
-                        <TabItem Header=" FLIGHT CONTROL &amp; AVIONICS" Controls:ControlsHelper.HeaderFontSize="24" Margin="205,-46,-205,46">
-                            <Grid Margin="0,-35,0,23.667" Background="#7F202020" x:Name="BackGroundBox1">
+                        <TabItem Header=" FLIGHT CONTROL &amp; AVIONICS" Margin="205,-46,-205,46" Style="{StaticResource SubTabHeader}">
+                            <Grid Margin="0,-35,0,23.667" Background="{StaticResource PanelBgBrush}" x:Name="BackGroundBox1">
                                 <!-- Roll Axis -->
                                 <Grid HorizontalAlignment="Left" Height="180" VerticalAlignment="Top" Width="480">
                                     <Label Content="SSC (Side Stick Controller)" Margin="10,10,0,0" Style="{StaticResource AxisHeading}"/>
 
                                     <Label Content="Roll : " Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_Roll" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_Roll" Margin="188,51,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Roll" Margin="32,85,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="Roll" Margin="320,77,0,0" RenderTransformOrigin="0.216,1.519" Style="{StaticResource AssignButton}"/>
 
                                     <Label Content="Pitch :" Margin="32,100,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_Pitch" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_Pitch" Margin="188,100,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Pitch" Margin="32,134,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="Pitch" Margin="320,126,0,0" Style="{StaticResource AssignButton}"/>
                                 </Grid>
@@ -372,12 +288,12 @@
                                     <Label Content="TQS (Throttle Quadrant System)" Margin="10,10,0,0" Style="{StaticResource AxisHeading}"/>
 
                                     <Label Content="Throttle :" Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_Throttle" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_Throttle" Margin="188,51,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Throttle" Margin="32,85,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="Throttle" Margin="320,77,0,0" Style="{StaticResource AssignButton}"/>
 
                                     <Label Content="Throttle Right :" Margin="32,100,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_Throttle_Right" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_Throttle_Right" Margin="188,100,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Throttle_Right" Margin="32,134,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="Throttle_Right" Margin="320,126,0,0" Style="{StaticResource AssignButton}"/>
 
@@ -393,17 +309,17 @@
                                     <Label Content="Rudder" Margin="10,10,0,177" Style="{StaticResource AxisHeading}" Grid.ColumnSpan="3"/>
 
                                     <Label Content="Yaw :" Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_Yaw" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100" Grid.ColumnSpan="2"/>
+                                    <Label x:Name="Label_Yaw" Margin="188,51,0,0" Style="{StaticResource AxisLabel}" Grid.ColumnSpan="2"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Yaw" Margin="32,85,0,0" Style="{StaticResource AxisBar}" Grid.ColumnSpan="2"/>
                                     <Button x:Name="Yaw" Margin="71.778,77,0,0" Style="{StaticResource AssignButton}" Grid.ColumnSpan="2" Grid.Column="1"/>
 
                                     <Label Content="Toe Brake :" Margin="32,100,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_Toe_Brake" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100" Grid.ColumnSpan="2"/>
+                                    <Label x:Name="Label_Toe_Brake" Margin="188,100,0,0" Style="{StaticResource AxisLabel}" Grid.ColumnSpan="2"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Toe_Brake" Margin="32,134,0,0" Style="{StaticResource AxisBar}" Grid.ColumnSpan="2"/>
                                     <Button x:Name="Toe_Brake" Margin="71.778,126,0,0" Style="{StaticResource AssignButton}" Grid.ColumnSpan="2" Grid.Column="1"/>
 
                                     <Label Content="Toe Brake Right :" Margin="32,149,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_Toe_Brake_Right" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,149,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100" Grid.ColumnSpan="2"/>
+                                    <Label x:Name="Label_Toe_Brake_Right" Margin="188,149,0,0" Style="{StaticResource AxisLabel}" Grid.ColumnSpan="2"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Toe_Brake_Right" Margin="32,183,0,0" Style="{StaticResource AxisBar}" Grid.ColumnSpan="2"/>
                                     <Button x:Name="Toe_Brake_Right" Margin="71.778,175,0,0" Style="{StaticResource AssignButton}" Grid.ColumnSpan="2" Grid.Column="1"/>
                                 </Grid>
@@ -411,17 +327,17 @@
                                     <Label Content="TRIM Panel" Margin="10,10,-18,177" Style="{StaticResource AxisHeading}"/>
 
                                     <Label Content="Trim Roll :" Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_Trim_Roll" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_Trim_Roll" Margin="188,51,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Trim_Roll" Margin="32,85,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="Trim_Roll" Margin="320,77,0,0" Style="{StaticResource AssignButton}"/>
 
                                     <Label Content="Trim Pitch :" Margin="32,100,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_Trim_Pitch" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_Trim_Pitch" Margin="188,100,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Trim_Pitch" Margin="32,134,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="Trim_Pitch" Margin="320,126,0,0" Style="{StaticResource AssignButton}"/>
 
                                     <Label Content="Trim Yaw :" Margin="32,149,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_Trim_Yaw" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,149,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_Trim_Yaw" Margin="188,149,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Trim_Yaw" Margin="32,183,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="Trim_Yaw" Margin="320,175,0,0" Style="{StaticResource AssignButton}"/>
                                 </Grid>
@@ -436,54 +352,58 @@
                                     <Label Content="TQS Avionics" Margin="10,10,-18,177" Style="{StaticResource AxisHeading}"/>
 
                                     <Label Content="Antenna Elev :" Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_Radar_Antenna_Elevation" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_Radar_Antenna_Elevation" Margin="188,51,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Radar_Antenna_Elevation" Margin="32,85,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="Radar_Antenna_Elevation" Margin="320,77,0,0" Style="{StaticResource AssignButton}"/>
 
                                     <Label Content="Cursor X :" Margin="32,100,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_Cursor_X" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_Cursor_X" Margin="188,100,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Cursor_X" Margin="32,134,0,0" VerticalAlignment="Top" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="Cursor_X" Margin="320,126,0,0" Style="{StaticResource AssignButton}"/>
 
                                     <Label Content="Cursor Y :" Margin="32,149,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_Cursor_Y" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,149,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_Cursor_Y" Margin="188,149,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Cursor_Y" Margin="32,183,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="Cursor_Y" Margin="320,175,0,0" Style="{StaticResource AssignButton}"/>
 
                                     <Label Content="Range Knob :" Margin="32,198,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_Range_Knob" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,198,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_Range_Knob" Margin="188,198,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Range_Knob" Margin="32,232,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="Range_Knob" Margin="320,224,0,0" Style="{StaticResource AssignButton}"/>
                                 </Grid>
-                                <TextBlock HorizontalAlignment="Left" Margin="102,355,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Height="55" Width="378"><Run Text="&quot;Throttle&quot; works as "/><Run Text="&quot;"/><Run Text="Both Throttle"/><Run Text="&quot;"/><Run Text=" "/><Run Text="for twin engine jets"/><Run Text=" "/><Run Text="as long as no axis are applied to &quot;Throttle Right"/><Run Text="&quot; "/><Run Text="or it "/><Run Text="will work as &quot;Throttle Left&quot;"/><LineBreak/><Run Text="For F-16 &quot;Throttle&quot; works as a main engine."/><LineBreak/></TextBlock>
-                                <CheckBox x:Name="Misc_RollLinkedNWS" Content="Use Roll Axis for Steering while on the Ground enabling NWS." HorizontalAlignment="Left" Margin="512,533,0,0" VerticalAlignment="Top" Height="18" Width="349"/>
+                                <TextBlock Margin="102,355,0,0" Height="55" Width="378" Style="{StaticResource HelpText}"><Run Text="&quot;Throttle&quot; works as "/><Run Text="&quot;"/><Run Text="Both Throttle"/><Run Text="&quot;"/><Run Text=" "/><Run Text="for twin engine jets"/><Run Text=" "/><Run Text="as long as no axis are applied to &quot;Throttle Right"/><Run Text="&quot; "/><Run Text="or it "/><Run Text="will work as &quot;Throttle Left&quot;"/><LineBreak/><Run Text="For F-16 &quot;Throttle&quot; works as a main engine."/><LineBreak/></TextBlock>
+                                <CheckBox x:Name="Misc_RollLinkedNWS"
+          Foreground="White"
+          Content="Use Roll Axis for Steering while on the Ground enabling NWS."
+          HorizontalAlignment="Left" Margin="512,533,0,0" VerticalAlignment="Top"
+          Height="18" Width="349"/>
                                 <Label Content="*Enabling this option disables Yaw axis." FontSize="11" HorizontalAlignment="Left" Margin="530,550,0,0" VerticalAlignment="Top" Height="25" Width="273"/>
-                                <TextBlock HorizontalAlignment="Left" Margin="32,574,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Height="36" Width="378"><Run Text="&quot;Toe Brake&quot; works as &quot;"/><Run Text="Both Toe Brakes"/><Run Text="&quot;"/><Run Text=" "/><Run Text="as long as no axis are applied to &quot;Toe Brake Right"/><Run Text="&quot; "/><Run Text="or it "/><Run Text="will work as &quot;Throttle Left&quot; &quot;Toe Brake Left&quot;"/><LineBreak/></TextBlock>
-                                <TextBlock HorizontalAlignment="Left" Margin="32,145,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Height="35" Width="378"><Run Text="FalconBMS implements real F-16 FLCS curve. "/><LineBreak/><Run Text="Disable any Deadzone and Saturation/Curve recommended"/></TextBlock>
+                                <TextBlock Margin="32,574,0,0" Height="36" Width="378" Style="{StaticResource HelpText}"><Run Text="&quot;Toe Brake&quot; works as &quot;"/><Run Text="Both Toe Brakes"/><Run Text="&quot;"/><Run Text=" "/><Run Text="as long as no axis are applied to &quot;Toe Brake Right"/><Run Text="&quot; "/><Run Text="or it "/><Run Text="will work as &quot;Throttle Left&quot; &quot;Toe Brake Left&quot;"/><LineBreak/></TextBlock>
+                                <TextBlock Margin="32,145,0,0" Height="35" Width="378" Style="{StaticResource HelpText}"><Run Text="FalconBMS implements real F-16 FLCS curve. "/><LineBreak/><Run Text="Disable any Deadzone and Saturation/Curve recommended"/></TextBlock>
                             </Grid>
                         </TabItem>
-                        <TabItem Header="ICP, RADIOS, AUDIO &amp; ALTIMETER" Controls:ControlsHelper.HeaderFontSize="24" Margin="205,-46,-204.333,46">
-                            <Grid Background="#7F202020" Margin="0,-35,0,23.667" x:Name="BackGroundBox2">
+                        <TabItem Header="ICP, RADIOS, AUDIO &amp; ALTIMETER" Margin="205,-46,-204.333,46" Style="{StaticResource SubTabHeader}">
+                            <Grid Background="{StaticResource PanelBgBrush}" Margin="0,-35,0,23.667" x:Name="BackGroundBox2">
                                 <Grid HorizontalAlignment="Left" Height="278" VerticalAlignment="Top" Width="480">
                                     <Label Content="ICP (Integrated Control Panel)" Margin="10,10,-18,177" Style="{StaticResource AxisHeading}"/>
 
                                     <Label Content="HUD Bright :" Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_HUD_Brightness" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_HUD_Brightness" Margin="188,51,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_HUD_Brightness" Margin="32,85,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="HUD_Brightness" Margin="320,77,0,0" Style="{StaticResource AssignButton}"/>
 
                                     <Label Content="Reticle Depr :" Margin="32,100,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_Reticle_Depression" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_Reticle_Depression" Margin="188,100,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Reticle_Depression" Margin="32,134,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="Reticle_Depression" Margin="320,126,0,0" Style="{StaticResource AssignButton}"/>
 
                                     <Label Content="HMS Bright :" Margin="32,149,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_HMS_Brightness" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,149,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_HMS_Brightness" Margin="188,149,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_HMS_Brightness" Margin="32,183,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="HMS_Brightness" Margin="320,175,0,0" Style="{StaticResource AssignButton}"/>
 
                                     <Label x:Name="Name_FLIR_Brightness"  Content="FLIR Bright :" Margin="32,198,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_FLIR_Brightness" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,198,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_FLIR_Brightness" Margin="188,198,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_FLIR_Brightness" Margin="32,232,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="FLIR_Brightness" Margin="320,224,0,0" Style="{StaticResource AssignButton}"/>
                                 </Grid>
@@ -491,37 +411,37 @@
                                     <Label Content="AUDIO Panel" Margin="10,10,-18,177" Style="{StaticResource AxisHeading}"/>
 
                                     <Label Content="Intercom :" Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_Intercom" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_Intercom" Margin="188,51,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Intercom" Margin="32,85,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="Intercom" Margin="320,77,0,0" Style="{StaticResource AssignButton}"/>
 
                                     <Label Content="COMM Ch 1 :" Margin="32,100,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_COMM_Channel_1" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_COMM_Channel_1" Margin="188,100,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_COMM_Channel_1" Margin="32,134,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="COMM_Channel_1" Margin="320,126,0,0" Style="{StaticResource AssignButton}"/>
 
                                     <Label Content="COMM Ch 2 :" Margin="32,149,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_COMM_Channel_2" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,149,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_COMM_Channel_2" Margin="188,149,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_COMM_Channel_2" Margin="32,183,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="COMM_Channel_2" Margin="320,175,0,0" Style="{StaticResource AssignButton}"/>
 
                                     <Label Content="MSL Vol :" Margin="32,198,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_MSL_Volume" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,198,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_MSL_Volume" Margin="188,198,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_MSL_Volume" Margin="32,232,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="MSL_Volume" Margin="320,224,0,0" Style="{StaticResource AssignButton}"/>
 
                                     <Label Content="Threat Vol :" Margin="32,247,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_Threat_Volume" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,247,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_Threat_Volume" Margin="188,247,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Threat_Volume" Margin="32,281,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="Threat_Volume" Margin="320,273,0,0" Style="{StaticResource AssignButton}"/>
 
                                     <Label x:Name="Name_AI_vs_IVC" Content="AI vs IVC :" Margin="32,296,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_AI_vs_IVC" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,296,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_AI_vs_IVC" Margin="188,296,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_AI_vs_IVC" Margin="32,330,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="AI_vs_IVC" Margin="320,322,0,0" Style="{StaticResource AssignButton}"/>
 
                                     <Label x:Name="Name_ILS_Volume_Knob" Content="ILS Vol :" Margin="32,343,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_ILS_Volume_Knob" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,343,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_ILS_Volume_Knob" Margin="188,343,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_ILS_Volume_Knob" Margin="32,377,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="ILS_Volume_Knob" Margin="320,369,0,0" Style="{StaticResource AssignButton}"/>
                                 </Grid>
@@ -529,12 +449,12 @@
                                     <Label Content="HSI (Horizontal Situation Indicator)" Margin="10,10,0,0" Style="{StaticResource AxisHeading}"/>
 
                                     <Label Content="Course : " Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_HSI_Course_Knob" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_HSI_Course_Knob" Margin="188,51,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_HSI_Course_Knob" Margin="32,85,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="HSI_Course_Knob" Margin="320,77,0,0" Style="{StaticResource AssignButton}" RenderTransformOrigin="0.216,1.519"/>
 
                                     <Label Content="Heading :" Margin="32,100,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_HSI_Heading_Knob" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_HSI_Heading_Knob" Margin="188,100,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_HSI_Heading_Knob" Margin="32,134,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="HSI_Heading_Knob" Margin="320,126,0,0" Style="{StaticResource AssignButton}"/>
                                 </Grid>
@@ -542,35 +462,35 @@
                                     <Label Content="Altimeter" Margin="10,10,0,0" Style="{StaticResource AxisHeading}"/>
 
                                     <Label Content="Setting :" Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_Altimeter_Knob" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_Altimeter_Knob" Margin="188,51,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Altimeter_Knob" Margin="32,85,0,0" Style="{StaticResource AxisBar}"/>
                                     <Button x:Name="Altimeter_Knob" Margin="320,77,0,0" Style="{StaticResource AssignButton}"/>
 
                                 </Grid>
                             </Grid>
                         </TabItem>
-                        <TabItem Header="VIEW" Controls:ControlsHelper.HeaderFontSize="24" Margin="204.333,-46,-204.333,46">
-                            <Grid Background="#7F202020" Margin="0,-35,0,23.667" x:Name="BackGroundBox4">
+                        <TabItem Header="VIEW" Margin="204.333,-46,-204.333,46" Style="{StaticResource SubTabHeader}">
+                            <Grid Background="{StaticResource PanelBgBrush}" Margin="0,-35,0,23.667" x:Name="BackGroundBox4">
                                 <Grid HorizontalAlignment="Left" Height="278" VerticalAlignment="Top" Width="480" Grid.ColumnSpan="2"/>
                                 <Grid HorizontalAlignment="Left" Height="531" VerticalAlignment="Top" Width="480">
                                     <Label Content="VIEWS" Margin="10,10,0,0" Style="{StaticResource AxisHeading}"/>
 
                                     <Label Content="FOV : " Margin="32,51,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_FOV" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,51,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_FOV" Margin="188,51,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_FOV" HorizontalAlignment="Left" Margin="32,85,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
                                     <Button x:Name="FOV" Margin="320,77,0,0" Style="{StaticResource AssignButton}" RenderTransformOrigin="0.216,1.519"/>
 
                                     <Label Content="Distance :" Margin="32,100,0,0" Style="{StaticResource AxisTitle}"/>
-                                    <Label x:Name="Label_Camera_Distance" HorizontalContentAlignment="Right" HorizontalAlignment="Left" Margin="188,100,0,0" VerticalAlignment="Top" FontSize="16" Height="34" Width="100"/>
+                                    <Label x:Name="Label_Camera_Distance" Margin="188,100,0,0" Style="{StaticResource AxisLabel}"/>
                                     <Controls:MetroProgressBar x:Name="Axis_Camera_Distance" HorizontalAlignment="Left" Margin="32,134,0,0" VerticalAlignment="Top" Width="256" Height="10"/>
                                     <Button x:Name="Camera_Distance" Margin="320,126,0,0" Style="{StaticResource AssignButton}"/>
-                                    <Controls:ToggleSwitch x:Name="Misc_TrackIRZ" OnLabel="TrackIR Zoom Fov" OffLabel="TrackIR Head Forward" HorizontalContentAlignment="Right" FontSize="11" HorizontalAlignment="Left" Margin="47,10,0,0" VerticalAlignment="Top" Width="347"/>
+                                    <Controls:ToggleSwitch x:Name="Misc_TrackIRZ" OnContent="TrackIR Zoom Fov" OffContent="TrackIR Head Forward" Margin="228,10,0,0" Style="{StaticResource LauncherToggleSwitch}"/>
                                     <CheckBox x:Name="Misc_ExMouseLook" Content="External MouseLook" HorizontalAlignment="Left" Margin="32,192,0,0" VerticalAlignment="Top" />
-                                    <TextBlock Text="Allows the mouse to control the camera for external views. Note that if this is enabled, controlling the external camera with the POV hat will be disabled." TextWrapping="Wrap" Margin="56,215,0,82" FontSize="10"/>
+                                    <TextBlock Text="Allows the mouse to control the camera for external views. Note that if this is enabled, controlling the external camera with the POV hat will be disabled." Margin="56,215,0,82" Style="{StaticResource HelpText}"/>
                                     <CheckBox x:Name="Misc_NaturalHeadMovement" Content="Natural Head Movement" HorizontalAlignment="Left" Margin="32,258,0,0" VerticalAlignment="Top" />
-                                    <TextBlock Text="Using this option will provide a more realistic experience when looking back at your six o'clock position as it will take into account the torso movement necessary to do so (valid with and without TIR)." TextWrapping="Wrap" Margin="56,281,0,-4"  FontSize="10"/>
+                                    <TextBlock Text="Using this option will provide a more realistic experience when looking back at your six o'clock position as it will take into account the torso movement necessary to do so (valid with and without TIR)." TextWrapping="Wrap" Margin="56,281,0,-4" Style="{StaticResource HelpText}"/>
                                     <CheckBox x:Name="Misc_PilotModel" Content="Pilot Model" HorizontalAlignment="Left" Margin="32,338,0,0" VerticalAlignment="Top"  Height="17"/>
-                                    <TextBlock TextWrapping="Wrap" Margin="56,359,0,-61"  FontSize="10">
+                                    <TextBlock Margin="56,359,0,-61" Style="{StaticResource HelpText}">
                                         <Run Text="Shows Pilot Model in 3D cockpit with kneeboards. "/>
                                         <Hyperlink NavigateUri="http://www.weapondeliveryplanner.nl/" RequestNavigate="WDP_RequestNavigate" Foreground="#FF6CD2FF">
                                             Weapon Delivery Planner
@@ -579,8 +499,8 @@
                                     </TextBlock>
                                 </Grid>
                                 <Grid HorizontalAlignment="Left" Height="278" Margin="489,332,0,0" VerticalAlignment="Top" Width="485">
-                                    <Label Content="Smart Scaling" HorizontalAlignment="Stretch" VerticalAlignment="Top" Margin="10,10,10,0" Width="Auto" Height="48" FontSize="24" />
-                                    <TextBlock HorizontalAlignment="Left" Margin="32,63,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Height="Auto" Width="409">
+                                    <Label Content="SMART SCALING" Margin="26,17,0,0" Style="{StaticResource AxisHeading}" />
+                                    <TextBlock Margin="32,63,0,0" Style="{StaticResource HelpText}" Height="Auto" Width="409">
                                         <Bold><Run Text="Improving Target Orientation Discrimination Performance"/></Bold>
                                         <LineBreak />
                                         <LineBreak />
@@ -604,7 +524,7 @@
 
                 </Grid>
             </TabItem>
-            <TabItem Header="KEYMAPPING" Margin="535,-40,-536,40.333">
+            <TabItem Header="KEYMAPPING" Margin="535,-40,-536,40.333" Style="{StaticResource TabHeader}">
                 <Grid Margin="0,1,-0.333,0.333">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="334*"/>
@@ -639,13 +559,13 @@
                             <DataGridTemplateColumn Visibility="Hidden" />
                         </DataGrid.Columns>
                     </DataGrid>
-                    <Label Content="ASSIGNMENT " VerticalContentAlignment="Top" HorizontalAlignment="Left" Margin="10,0,0,32.334" VerticalAlignment="Bottom" RenderTransformOrigin="-4.878,1.143" FontWeight="Bold" Height="26" Width="89"/>
-                    <Label x:Name="Label_AssgnStatus" Content="KEYSEARCH MODE" VerticalContentAlignment="Top" HorizontalAlignment="Left" Margin="114,0,0,32.334" VerticalAlignment="Bottom" RenderTransformOrigin="-4.878,1.143" FontStyle="Italic" Height="26" Width="886" Grid.ColumnSpan="2"/>
+                    <Label Content="ASSIGNMENT" VerticalContentAlignment="Top" HorizontalAlignment="Left" Margin="10,0,0,32.334" VerticalAlignment="Bottom" RenderTransformOrigin="-4.878,1.143" FontWeight="Bold" Height="26" Width="89" Foreground="{StaticResource UiForegroundBrush}"/>
+                    <Label x:Name="Label_AssgnStatus" Content="KEYSEARCH MODE" VerticalContentAlignment="Top" HorizontalAlignment="Left" Margin="114,0,0,32.334" VerticalAlignment="Bottom" RenderTransformOrigin="-4.878,1.143" FontStyle="Italic" Height="26" Width="886" Foreground="{StaticResource UiForegroundBrush}" Grid.ColumnSpan="2"/>
 
                     <Label Content="Filter:" HorizontalAlignment="Left" Margin="227.167,-43,0,0" VerticalAlignment="Top" Width="43" HorizontalContentAlignment="Right" Foreground="White" Grid.Column="1"/>
                     <TextBox x:Name="SearchBox" HorizontalAlignment="Left" Height="23" Margin="282.167,-41,0,0" VerticalAlignment="Top" Width="384" Background="#80F0F0F0" Foreground="#FF191919" Controls:TextBoxHelper.ClearTextButton="True" TextChanged="SearchBox_TextChanged" Grid.Column="1"/>
 
-                    <Label Content="* Double Click a cell to Assign keys." HorizontalContentAlignment="Right" HorizontalAlignment="Right" Margin="0,0,9.666,30.334" VerticalAlignment="Bottom" Width="596" Height="29" Grid.Column="1"/>
+                    <Label Content="* Double Click a cell to Assign keys." HorizontalContentAlignment="Right" HorizontalAlignment="Right" Margin="0,0,9.666,30.334" VerticalAlignment="Bottom" Width="596" Height="29" Foreground="{StaticResource UiForegroundBrush}" Grid.Column="1"/>
 
                     <Button x:Name="ImportButton" Content="Import Key File..." HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="20,20,240,20" Width="129" Click="ImportKeyfile_Click" Height="27" Grid.Column="1"/>
                 </Grid>
@@ -653,6 +573,6 @@
         </TabControl>
         <Image x:Name="LOGO000" HorizontalAlignment="Left" VerticalAlignment="Top" Height="49" Source="/Resources/web_banner.png" Stretch="Uniform" Width="363" Margin="24,10,0,0"/>
         <Label x:Name="Version_Number" Content="4.37" HorizontalAlignment="Left" Margin="392,0,0,0" VerticalAlignment="Top" Foreground="#FFC4C4C4" FontSize="36"/>
-        <Label x:Name="AL_Version_Number" Content="FalconBMS Launcher vX.X.X" HorizontalContentAlignment="Right" HorizontalAlignment="Right" VerticalAlignment="Bottom" FontWeight="Bold" Margin="0,0,10.333,0.334" Grid.Row="1"/>
+        <Label x:Name="AL_Version_Number" Content="FalconBMS Launcher vX.X.X" HorizontalContentAlignment="Right" HorizontalAlignment="Right" VerticalAlignment="Bottom" FontWeight="Bold" Margin="0,0,10.333,0.334" Foreground="{StaticResource UiForegroundBrush}" Grid.Row="1"/>
     </Grid>
 </Controls:MetroWindow>

--- a/Falcon BMS Alternative Launcher/Windows/MainWindowKeyMapping.cs
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindowKeyMapping.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Interactivity;
 using System.Windows.Media;
 
 using FalconBMS.Launcher.Input;

--- a/Falcon BMS Alternative Launcher/app.manifest
+++ b/Falcon BMS Alternative Launcher/app.manifest
@@ -55,6 +55,7 @@
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
       <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>

--- a/Falcon BMS Alternative Launcher/packages.config
+++ b/Falcon BMS Alternative Launcher/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autoupdater.NET.Official" version="1.7.0" targetFramework="net461" />
-  <package id="ControlzEx" version="3.0.2.4" targetFramework="net461" />
-  <package id="MahApps.Metro" version="1.6.5" targetFramework="net461" />
+  <package id="ControlzEx" version="4.4.0" targetFramework="net48" />
+  <package id="MahApps.Metro" version="2.4.10" targetFramework="net48" />
+  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.19" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
This PR upgrades MahApps.Metro to v2 and moves inline control styles into a single, reusable Styles.xaml. It also introduces named brushes so we don't have to hardcode hex colors throughout the files.

**Changes**

- MahApps.Metro updated to v2.4.10 (packages + xmlns still MahApps.Metro)
- - Also required update to ControlzEx
- Consolidated more inline styles (TextBlock, CheckBox, Borders) into into Styles.xaml
- Resource brushes added and used throughout to replace inline hex colors
- TrackIR toggleswitch replaced with radio buttons