### PR TITLE
Creating gird-based layouts for launcher

### DIFF
--- a/Falcon BMS Alternative Launcher/Falcon BMS Alternative Launcher.csproj
+++ b/Falcon BMS Alternative Launcher/Falcon BMS Alternative Launcher.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Starter\AbstractStarter.cs" />
     <Compile Include="TheaterList.cs" />
     <Compile Include="Input\DetentPosition.cs" />
+    <Compile Include="Windows\LauncherCatalog.cs" />
     <Compile Include="Windows\RSSReader.cs" />
     <Page Include="Styles\Styles.xaml">
       <SubType>Designer</SubType>

--- a/Falcon BMS Alternative Launcher/Starter/AbstractStarter.cs
+++ b/Falcon BMS Alternative Launcher/Starter/AbstractStarter.cs
@@ -84,16 +84,8 @@ namespace FalconBMS.Launcher.Starter
 
         public void AVCSince433(bool flg)
         {
-            if (flg)
-            {
-                mainWindow.Launch_AVC.Visibility = Visibility.Visible;
-                mainWindow.Label_AVC.Visibility  = Visibility.Visible;
-            }
-            else
-            {
-                mainWindow.Launch_AVC.Visibility = Visibility.Hidden;
-                mainWindow.Label_AVC.Visibility  = Visibility.Hidden;
-            }
+            // Hide/show the Avionics Configurator button (and its label) by item Id.
+            mainWindow.SetPrimaryLauncherVisible("AVC", flg);
         }
 
         public void VRsince437(bool flg)
@@ -134,20 +126,9 @@ namespace FalconBMS.Launcher.Starter
 
         public void RTTsince435(bool flg)
         {
-            if (flg)
-            {
-                mainWindow.Launch_RTTC.Visibility = Visibility.Visible;
-                mainWindow.Label_RTTC.Visibility  = Visibility.Visible;
-                mainWindow.Launch_RTTS.Visibility = Visibility.Visible;
-                mainWindow.Label_RTTS.Visibility  = Visibility.Visible;
-            }
-            else
-            {
-                mainWindow.Launch_RTTC.Visibility = Visibility.Hidden;
-                mainWindow.Label_RTTC.Visibility  = Visibility.Hidden;
-                mainWindow.Launch_RTTS.Visibility = Visibility.Hidden;
-                mainWindow.Label_RTTS.Visibility  = Visibility.Hidden;
-            }
+            // Hide/show both RTT items by Id.
+            mainWindow.SetPrimaryLauncherVisible("RTTC", flg);
+            mainWindow.SetPrimaryLauncherVisible("RTTS", flg);
         }
 
     }

--- a/Falcon BMS Alternative Launcher/Styles/Styles.xaml
+++ b/Falcon BMS Alternative Launcher/Styles/Styles.xaml
@@ -144,10 +144,10 @@
     </Style>
     <Style x:Key="LauncherToggleSwitch" TargetType="Controls:ToggleSwitch" BasedOn="{StaticResource {x:Type Controls:ToggleSwitch}}">
         <Setter Property="FontSize" Value="11"/>
-        <Setter Property="HorizontalAlignment" Value="Left"/>
-        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+        <Setter Property="Margin" Value="10"/>
+        <Setter Property="HorizontalAlignment" Value="Right"/>
         <Setter Property="VerticalAlignment" Value="Top"/>
-        <Setter Property="Foreground" Value="#80FFFFFF" />
+        <Setter Property="Foreground" Value="{StaticResource UiForegroundBrush}" />
     </Style>
 
 
@@ -156,6 +156,51 @@
            BasedOn="{StaticResource {x:Type RadioButton}}">
         <Setter Property="HorizontalAlignment" Value="Left"/>
         <Setter Property="VerticalAlignment" Value="Top"/>
+    </Style>
+
+    <!-- App launcher buttons -->
+    <Style x:Key="LauncherButtonBase" TargetType="Button">
+        <Setter Property="Cursor" Value="Hand"/>
+        <Setter Property="HorizontalAlignment" Value="Stretch"/>
+        <Setter Property="VerticalAlignment" Value="Stretch"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <ContentPresenter HorizontalAlignment="Center"
+                                      VerticalAlignment="Top"/>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <Style x:Key="LauncherIcon" TargetType="Image">
+        <Setter Property="Width" Value="32"/>
+        <Setter Property="Height" Value="32"/>
+        <Setter Property="Stretch" Value="Uniform"/>
+    </Style>
+
+    <!-- App launcher titles -->
+    <Style x:Key="LauncherLabel" TargetType="TextBlock">
+        <Setter Property="Margin" Value="0,4,0,0"/>
+        <Setter Property="TextWrapping" Value="Wrap"/>
+        <Setter Property="TextAlignment" Value="Center"/>
+        <Setter Property="HorizontalAlignment" Value="Center"/>
+        <Setter Property="VerticalAlignment" Value="Top"/>
+        <Setter Property="Foreground" Value="#FFF0F0F0"/>
+        <Setter Property="FontWeight" Value="Bold"/>
+        <Setter Property="FontSize" Value="9"/>
+        <Setter Property="MaxWidth" Value="80"/>
+
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource GridFocusedFgBrush}"/>
+            </Trigger>
+
+            <!-- Hovering anywhere on the parent Button (icon OR text) -->
+            <DataTrigger Value="True"
+                     Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=Button}}">
+                <Setter Property="Foreground" Value="{DynamicResource GridFocusedFgBrush}"/>
+            </DataTrigger>
+        </Style.Triggers>
     </Style>
 
     <!-- AXISASSIGN tab -->

--- a/Falcon BMS Alternative Launcher/Styles/Styles.xaml
+++ b/Falcon BMS Alternative Launcher/Styles/Styles.xaml
@@ -248,6 +248,7 @@
         <Setter Property="Background" Value="#FFFFFFFF"/>
         <Setter Property="BorderBrush" Value="{x:Null}"/>
         <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Cursor" Value="Hand"/>
         <Setter Property="Content" Value="Assign"/>
     </Style>
     <Style x:Key="AxisBar"

--- a/Falcon BMS Alternative Launcher/Styles/Styles.xaml
+++ b/Falcon BMS Alternative Launcher/Styles/Styles.xaml
@@ -23,6 +23,9 @@
     <SolidColorBrush x:Key="MahApps.Brushes.ToggleSwitch.KnobFillOffPointerOver" Color="#6888" />
     <SolidColorBrush x:Key="MahApps.Brushes.ToggleSwitch.FillOffPointerOver" Color="#6222" />
 
+    <SolidColorBrush x:Key="LauncherHoverBorderBrush" Color="#7FC0E8FF"/>
+    <SolidColorBrush x:Key="LauncherHoverLabelBrush"  Color="#FF4DB5FF"/>
+
     <Style TargetType="DataGridDetailsPresenter">
         <Setter Property="HorizontalAlignment" Value="Left"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
@@ -189,18 +192,81 @@
         <Setter Property="FontWeight" Value="Bold"/>
         <Setter Property="FontSize" Value="9"/>
         <Setter Property="MaxWidth" Value="80"/>
+    </Style>
 
-        <Style.Triggers>
-            <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Foreground" Value="{DynamicResource GridFocusedFgBrush}"/>
-            </Trigger>
 
-            <!-- Hovering anywhere on the parent Button (icon OR text) -->
-            <DataTrigger Value="True"
-                     Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=Button}}">
-                <Setter Property="Foreground" Value="{DynamicResource GridFocusedFgBrush}"/>
-            </DataTrigger>
-        </Style.Triggers>
+    <!-- Shared button visuals for strip items (image + label + optional sublabel) -->
+    <Style x:Key="LauncherStripButtonStyle"
+       TargetType="Button"
+       BasedOn="{StaticResource LauncherButtonBase}">
+        <!-- Carry the logical Id so code-behind can route -->
+        <Setter Property="Tag" Value="{Binding Id}"/>
+        <Setter Property="Padding" Value="0"/>
+        <Setter Property="Margin"  Value="6,0,6,0"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="BorderThickness" Value="0"/>
+
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Bd"
+              Background="{TemplateBinding Background}"
+              BorderBrush="{TemplateBinding BorderBrush}"
+              BorderThickness="{TemplateBinding BorderThickness}"
+              CornerRadius="4"
+              SnapsToDevicePixels="True"
+              Padding="2">
+
+                        <Grid VerticalAlignment="Top">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="32"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+
+                            <!-- Icon (row 0) -->
+                            <Image Grid.Row="0"
+                 Source="{Binding IconPath}"
+                 Style="{StaticResource LauncherIcon}" />
+
+                            <!-- Labels (row 1) -->
+                            <StackPanel Grid.Row="1"
+                      Orientation="Vertical"
+                      HorizontalAlignment="Center">
+                                <TextBlock x:Name="Lbl"
+                       Text="{Binding Label}"
+                       Style="{StaticResource LauncherLabel}"
+                       TextAlignment="Center"
+                       Margin="0,2,0,0"/>
+                                <TextBlock x:Name="SubLbl"
+                       Text="{Binding SubLabel}"
+                       Style="{StaticResource LauncherLabel}"
+                       TextAlignment="Center"
+                       Margin="0,-2,0,0"
+                       Visibility="Visible"/>
+                            </StackPanel>
+                        </Grid>
+                    </Border>
+
+                    <ControlTemplate.Triggers>
+                        <!-- Hide SubLbl when empty -->
+                        <Trigger SourceName="SubLbl" Property="Text" Value="">
+                            <Setter TargetName="SubLbl" Property="Visibility" Value="Collapsed"/>
+                        </Trigger>
+
+                        <!-- Hover labels -->
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Lbl"    Property="Foreground" Value="{StaticResource LauncherHoverLabelBrush}"/>
+                            <Setter TargetName="SubLbl" Property="Foreground" Value="{StaticResource LauncherHoverLabelBrush}"/>
+                        </Trigger>
+
+                        <!-- Disabled -->
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.6"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!-- AXISASSIGN tab -->

--- a/Falcon BMS Alternative Launcher/Windows/LauncherCatalog.cs
+++ b/Falcon BMS Alternative Launcher/Windows/LauncherCatalog.cs
@@ -1,0 +1,120 @@
+﻿using System.Collections.Generic;
+
+namespace FalconBMS.Launcher.Windows
+{
+    public enum LauncherRoute { Primary, ThirdParty }
+
+    public sealed class LauncherItem
+    {
+        public string Id { get; set; }         // e.g., "WDP"
+        public string Label { get; set; }      // e.g., "Weapon Delivery Planner"
+        public string SubLabel { get; set; }   // optional second line
+        public string IconPath { get; set; }   // e.g., "/Resources/WDP.png"
+        public LauncherRoute Route { get; set; }
+    }
+
+    public static class LauncherCatalog
+    {
+        // Map the image location
+        private const string Pack = "pack://application:,,,/FalconBMS_Alternative_Launcher;component/Resources/";
+
+        // Primary strip (9 columns)
+        public static IReadOnlyList<LauncherItem> PrimaryStrip => _primaryStrip;
+        private static readonly List<LauncherItem> _primaryStrip = new List<LauncherItem>
+        {
+            new LauncherItem { 
+                Id="UPD",  
+                Label="Update",
+                IconPath=$"{Pack}UPD.png",
+                Route=LauncherRoute.Primary
+            },
+            new LauncherItem { 
+                Id="CFG",  
+                Label="Config",
+                IconPath=$"{Pack}CFG.png",
+                Route=LauncherRoute.Primary
+            },
+            new LauncherItem { 
+                Id="MMC",  
+                Label="Display Config",
+                IconPath=$"{Pack}BmsMultiMon.png",
+                Route=LauncherRoute.Primary
+            },
+            new LauncherItem { 
+                Id="RTTC", 
+                Label="RTT Client",
+                IconPath=$"{Pack}RTTClient64.png",
+                Route=LauncherRoute.Primary
+            },
+            new LauncherItem { 
+                Id="RTTS", 
+                Label="RTT Server",
+                IconPath=$"{Pack}RTTServer64.png",     
+                Route=LauncherRoute.Primary
+            },
+            new LauncherItem { 
+                Id="IVCC", 
+                Label="IVC Client", 
+                SubLabel="(MP Radio)",
+                IconPath=$"{Pack}IVCC.png", 
+                Route=LauncherRoute.Primary
+            },
+            new LauncherItem { 
+                Id="IVCS", 
+                Label="IVC Server", 
+                SubLabel="(MP Radio)",
+                IconPath=$"{Pack}IVCS.png", 
+                Route=LauncherRoute.Primary
+            },
+            new LauncherItem { 
+                Id="AVC",
+                Label="Avionics",
+                SubLabel="Configurator",
+                IconPath=$"{Pack}AVC.png",
+                Route=LauncherRoute.Primary
+            },
+            new LauncherItem { 
+                Id="EDIT",
+                Label="Editor",
+                IconPath=$"{Pack}EDIT.png",
+                Route=LauncherRoute.Primary
+            },
+        };
+
+        // Third-party strip (5 columns)
+        public static IReadOnlyList<LauncherItem> ThirdPartyStrip => _thirdPartyStrip;
+        private static readonly List<LauncherItem> _thirdPartyStrip = new List<LauncherItem>
+        {
+            new LauncherItem { 
+                Id="WDP",
+                Label="Weapon Delivery Planner",
+                IconPath=$"{Pack}WDP.png",
+                Route=LauncherRoute.ThirdParty 
+            },
+            new LauncherItem { 
+                Id="MC", 
+                Label="Mission Commander",
+               IconPath=$"{Pack}MC.png", 
+                Route=LauncherRoute.ThirdParty
+            },
+            new LauncherItem { 
+                Id="WC",
+                Label="Weather Commander",
+               IconPath=$"{Pack}WC.png", 
+                Route=LauncherRoute.ThirdParty 
+            },
+            new LauncherItem { 
+                Id="F4WX",
+                Label="F4Wx Real Weather",
+                IconPath=$"{Pack}F4WX.png",
+                Route=LauncherRoute.ThirdParty
+            },
+            new LauncherItem { 
+                Id="F4RADAR", 
+                Label="F4 RADAR C2 (AWACS) Tool",
+               IconPath=$"{Pack}F4RADAR.png", 
+                Route=LauncherRoute.ThirdParty 
+            },
+        };
+    }
+}

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -52,263 +52,11 @@
             <TabItem Header="LAUNCHER" x:Name="Tab_Launcher" Margin="535,-40,-535.333,40.333" Style="{StaticResource TabHeader}">
                 <Grid>
 
-                    <CheckBox x:Name="ApplicationOverride" Content="Launch without applying overrides" HorizontalAlignment="Right" Margin="0,0,20,98" MinWidth="206" VerticalAlignment="Bottom" Background="#FFECFF71" Foreground="{StaticResource UiForegroundBrush}" />
-
-                    <Border BorderThickness="1"
-        HorizontalAlignment="Left"
-        Height="72"
-        Width="638"
-        Margin="48,0,0,97"
-        VerticalAlignment="Bottom"
-        Style="{StaticResource LauncherStripBorder}">
-
-                        <Grid VerticalAlignment="Center">
-                            <!-- 9 columns -->
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
-                            </Grid.ColumnDefinitions>
-
-                            <!-- Rows: Row 0 = icons, Row 1 = labels -->
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="32"/>
-                                <RowDefinition Height="Auto"/>
-                            </Grid.RowDefinitions>
-                            
-                            <Grid.Resources>
-                                <Style x:Key="LauncherButton" TargetType="Button" BasedOn="{StaticResource LauncherButtonBase}">
-                                    <EventSetter Event="Click" Handler="Launch_Click"/>
-                                    <EventSetter Event="MouseEnter" Handler="MouseEnterLauncher"/>
-                                    <EventSetter Event="MouseLeave" Handler="MouseLeaveLauncher"/>
-                                </Style>
-                            </Grid.Resources>
-
-                            <!-- 1) Update -->
-                            <Button x:Name="Launch_UPD"
-                Grid.Column="0" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/UPD.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_UPD"
-                           Text="Update"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 2) Config -->
-                            <Button x:Name="Launch_CFG"
-                Grid.Column="1" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/CFG.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_CFG"
-                           Text="Config"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 3) Display Config -->
-                            <Button x:Name="Launch_MMC"
-                Grid.Column="2" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/BmsMultiMon.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_MMC"
-                           Text="Display Config"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 4) RTT Client -->
-                            <Button x:Name="Launch_RTTC"
-                Grid.Column="3" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/RTTClient64.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_RTTC"
-                           Text="RTT Client"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 5) RTT Server -->
-                            <Button x:Name="Launch_RTTS"
-                Grid.Column="4" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/RTTServer64.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_RTTS"
-                           Text="RTT Server"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 6) IVC Client (MP Radio) -->
-                            <Button x:Name="Launch_IVCC"
-                Grid.Column="5" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/IVCC.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_IVCC"
-                           Style="{StaticResource LauncherLabel}">
-                    <Run Text="IVC Client"/>
-                    <LineBreak/>
-                    <Run Text="(MP Radio)"/>
-                                    </TextBlock>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 7) IVC Server (MP Radio) -->
-                            <Button x:Name="Launch_IVCS"
-                Grid.Column="6" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/IVCS.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_IVCS"
-                           Style="{StaticResource LauncherLabel}">
-                    <Run Text="IVC Server"/>
-                    <LineBreak/>
-                    <Run Text="(MP Radio)"/>
-                                    </TextBlock>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 8) Avionics Configurator -->
-                            <Button x:Name="Launch_AVC"
-                Grid.Column="7" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/AVC.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_AVC"
-                           Style="{StaticResource LauncherLabel}">
-                    <Run Text="Avionics"/>
-                    <LineBreak/>
-                    <Run Text="Configurator"/>
-                                    </TextBlock>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 9) Editor -->
-                            <Button x:Name="Launch_EDIT"
-                Grid.Column="8" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/EDIT.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_EDIT"
-                           Text="Editor"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-                        </Grid>
-                    </Border>
-
-
-                    <Border BorderThickness="1"
-        HorizontalAlignment="Left"
-        Height="72"
-        Width="480"
-        Margin="48,0,0,20"
-        VerticalAlignment="Bottom"
-        Style="{StaticResource LauncherStripBorder}">
-
-                        <Grid VerticalAlignment="Center">
-                            <!-- 5 columns -->
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-
-                            <!-- Rows: Row 0 = icons, Row 1 = labels -->
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="32"/>
-                                <RowDefinition Height="Auto"/>
-                            </Grid.RowDefinitions>
-
-                            <Grid.Resources>
-                                <Style x:Key="LauncherButton" TargetType="Button" BasedOn="{StaticResource LauncherButtonBase}">
-                                    <EventSetter Event="Click" Handler="Launch_Third"/>
-                                    <EventSetter Event="MouseEnter" Handler="MouseEnterLauncher"/>
-                                    <EventSetter Event="MouseLeave" Handler="MouseLeaveLauncher"/>
-                                </Style>
-                            </Grid.Resources>
-
-                            <!-- 1) Weapon Delivery Planner -->
-                            <Button x:Name="Launch_WDP"
-                Grid.Column="0" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/WDP.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_WDP"
-                           Text="Weapon Delivery Planner"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 2) Mission Commander -->
-                            <Button x:Name="Launch_MC"
-                Grid.Column="1" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/MC.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_MC"
-                           Text="Mission Commander"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 3) Weather Commander -->
-                            <Button x:Name="Launch_WC"
-                Grid.Column="2" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/WC.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_WC"
-                           Text="Weather Commander"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 4) F4Wx Real Weather -->
-                            <Button x:Name="Launch_F4WX"
-                Grid.Column="3" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/F4WX.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_F4WX"
-                           Text="F4Wx Real Weather"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 5) F4 RADAR C2 (AWACS) Tool -->
-                            <Button x:Name="Launch_F4RADAR"
-                Grid.Column="4" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/F4RADAR.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_F4RADAR"
-                           Text="F4 RADAR C2 (AWACS) Tool"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-                        </Grid>
-                    </Border>
-
-
-                    <Button x:Name="Launch_BMS_Large" Content="LAUNCH" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" Controls:ControlsHelper.ContentCharacterCasing="Normal" HorizontalAlignment="Right" Margin="20,20,20,20" VerticalAlignment="Bottom" Width="208" Click="Launch_Click" Height="72" Background="#CC2494FF" BorderBrush="{x:Null}" FontSize="24" Grid.Row="1"/>
-                    <ListBox x:Name="ListBox_BMS" SelectionChanged="ListBox_BMS_SelectionChanged" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="20,20,240,20" Width="220" Height="72" SelectionMode="Single" d:ItemsSource="{d:SampleData ItemCount=5}" Style="{StaticResource LauncherListBox}">
-                    </ListBox>
-
+                    <Label Content="News" HorizontalAlignment="Left" Margin="48,10,0,0" VerticalAlignment="Top" FontSize="24" FontWeight="Bold" FontStyle="Italic" Foreground="{StaticResource UiForegroundBrush}"/>
+                    <ScrollViewer x:Name ="LogTextScroll" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Margin="48,60,460,350" Background="#5000">
+                        <TextBlock x:Name="News" HorizontalAlignment="Left" TextWrapping="Wrap" Text="" VerticalAlignment="Top" Height="Auto" Width="380" Margin="20,20,0,0" />
+                    </ScrollViewer>                    
+                    
                     <Grid HorizontalAlignment="Left"
           VerticalAlignment="Bottom"
           Width="480"
@@ -439,10 +187,254 @@
 
                     </Grid>
 
-                    <Label Content="News" HorizontalAlignment="Left" Margin="48,10,0,0" VerticalAlignment="Top" FontSize="24" FontWeight="Bold" FontStyle="Italic" Foreground="{StaticResource UiForegroundBrush}"/>
-                    <ScrollViewer x:Name ="LogTextScroll" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Margin="48,60,460,350" Background="#5000">
-                        <TextBlock x:Name="News" HorizontalAlignment="Left" TextWrapping="Wrap" Text="" VerticalAlignment="Top" Height="Auto" Width="380" Margin="20,20,0,0" />
-                    </ScrollViewer>
+                    <Border BorderThickness="1"
+        HorizontalAlignment="Left"
+        Height="72"
+        Width="638"
+        Margin="48,0,0,97"
+        VerticalAlignment="Bottom"
+        Style="{StaticResource LauncherStripBorder}">
+
+                        <Grid VerticalAlignment="Center">
+                            <!-- 9 columns -->
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+
+                            <!-- Rows: Row 0 = icons, Row 1 = labels -->
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="32"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+
+                            <Grid.Resources>
+                                <Style x:Key="LauncherButton" TargetType="Button" BasedOn="{StaticResource LauncherButtonBase}">
+                                    <EventSetter Event="Click" Handler="Launch_Click"/>
+                                    <EventSetter Event="MouseEnter" Handler="MouseEnterLauncher"/>
+                                    <EventSetter Event="MouseLeave" Handler="MouseLeaveLauncher"/>
+                                </Style>
+                            </Grid.Resources>
+
+                            <!-- 1) Update -->
+                            <Button x:Name="Launch_UPD"
+                Grid.Column="0" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherButton}">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/UPD.png" Style="{StaticResource LauncherIcon}"/>
+                                    <TextBlock x:Name="Label_UPD"
+                           Text="Update"
+                           Style="{StaticResource LauncherLabel}"/>
+                                </StackPanel>
+                            </Button>
+
+                            <!-- 2) Config -->
+                            <Button x:Name="Launch_CFG"
+                Grid.Column="1" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherButton}">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/CFG.png" Style="{StaticResource LauncherIcon}"/>
+                                    <TextBlock x:Name="Label_CFG"
+                           Text="Config"
+                           Style="{StaticResource LauncherLabel}"/>
+                                </StackPanel>
+                            </Button>
+
+                            <!-- 3) Display Config -->
+                            <Button x:Name="Launch_MMC"
+                Grid.Column="2" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherButton}">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/BmsMultiMon.png" Style="{StaticResource LauncherIcon}"/>
+                                    <TextBlock x:Name="Label_MMC"
+                           Text="Display Config"
+                           Style="{StaticResource LauncherLabel}"/>
+                                </StackPanel>
+                            </Button>
+
+                            <!-- 4) RTT Client -->
+                            <Button x:Name="Launch_RTTC"
+                Grid.Column="3" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherButton}">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/RTTClient64.png" Style="{StaticResource LauncherIcon}"/>
+                                    <TextBlock x:Name="Label_RTTC"
+                           Text="RTT Client"
+                           Style="{StaticResource LauncherLabel}"/>
+                                </StackPanel>
+                            </Button>
+
+                            <!-- 5) RTT Server -->
+                            <Button x:Name="Launch_RTTS"
+                Grid.Column="4" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherButton}">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/RTTServer64.png" Style="{StaticResource LauncherIcon}"/>
+                                    <TextBlock x:Name="Label_RTTS"
+                           Text="RTT Server"
+                           Style="{StaticResource LauncherLabel}"/>
+                                </StackPanel>
+                            </Button>
+
+                            <!-- 6) IVC Client (MP Radio) -->
+                            <Button x:Name="Launch_IVCC"
+                Grid.Column="5" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherButton}">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/IVCC.png" Style="{StaticResource LauncherIcon}"/>
+                                    <TextBlock x:Name="Label_IVCC"
+                           Style="{StaticResource LauncherLabel}">
+                    <Run Text="IVC Client"/>
+                    <LineBreak/>
+                    <Run Text="(MP Radio)"/>
+                                    </TextBlock>
+                                </StackPanel>
+                            </Button>
+
+                            <!-- 7) IVC Server (MP Radio) -->
+                            <Button x:Name="Launch_IVCS"
+                Grid.Column="6" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherButton}">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/IVCS.png" Style="{StaticResource LauncherIcon}"/>
+                                    <TextBlock x:Name="Label_IVCS"
+                           Style="{StaticResource LauncherLabel}">
+                    <Run Text="IVC Server"/>
+                    <LineBreak/>
+                    <Run Text="(MP Radio)"/>
+                                    </TextBlock>
+                                </StackPanel>
+                            </Button>
+
+                            <!-- 8) Avionics Configurator -->
+                            <Button x:Name="Launch_AVC"
+                Grid.Column="7" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherButton}">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/AVC.png" Style="{StaticResource LauncherIcon}"/>
+                                    <TextBlock x:Name="Label_AVC"
+                           Style="{StaticResource LauncherLabel}">
+                    <Run Text="Avionics"/>
+                    <LineBreak/>
+                    <Run Text="Configurator"/>
+                                    </TextBlock>
+                                </StackPanel>
+                            </Button>
+
+                            <!-- 9) Editor -->
+                            <Button x:Name="Launch_EDIT"
+                Grid.Column="8" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherButton}">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/EDIT.png" Style="{StaticResource LauncherIcon}"/>
+                                    <TextBlock x:Name="Label_EDIT"
+                           Text="Editor"
+                           Style="{StaticResource LauncherLabel}"/>
+                                </StackPanel>
+                            </Button>
+                        </Grid>
+                    </Border>
+
+                    <Border BorderThickness="1"
+        HorizontalAlignment="Left"
+        Height="72"
+        Width="480"
+        Margin="48,0,0,20"
+        VerticalAlignment="Bottom"
+        Style="{StaticResource LauncherStripBorder}">
+
+                        <Grid VerticalAlignment="Center">
+                            <!-- 5 columns -->
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+
+                            <!-- Rows: Row 0 = icons, Row 1 = labels -->
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="32"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+
+                            <Grid.Resources>
+                                <Style x:Key="LauncherButton" TargetType="Button" BasedOn="{StaticResource LauncherButtonBase}">
+                                    <EventSetter Event="Click" Handler="Launch_Third"/>
+                                    <EventSetter Event="MouseEnter" Handler="MouseEnterLauncher"/>
+                                    <EventSetter Event="MouseLeave" Handler="MouseLeaveLauncher"/>
+                                </Style>
+                            </Grid.Resources>
+
+                            <!-- 1) Weapon Delivery Planner -->
+                            <Button x:Name="Launch_WDP"
+                Grid.Column="0" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherButton}">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/WDP.png" Style="{StaticResource LauncherIcon}"/>
+                                    <TextBlock x:Name="Label_WDP"
+                           Text="Weapon Delivery Planner"
+                           Style="{StaticResource LauncherLabel}"/>
+                                </StackPanel>
+                            </Button>
+
+                            <!-- 2) Mission Commander -->
+                            <Button x:Name="Launch_MC"
+                Grid.Column="1" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherButton}">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/MC.png" Style="{StaticResource LauncherIcon}"/>
+                                    <TextBlock x:Name="Label_MC"
+                           Text="Mission Commander"
+                           Style="{StaticResource LauncherLabel}"/>
+                                </StackPanel>
+                            </Button>
+
+                            <!-- 3) Weather Commander -->
+                            <Button x:Name="Launch_WC"
+                Grid.Column="2" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherButton}">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/WC.png" Style="{StaticResource LauncherIcon}"/>
+                                    <TextBlock x:Name="Label_WC"
+                           Text="Weather Commander"
+                           Style="{StaticResource LauncherLabel}"/>
+                                </StackPanel>
+                            </Button>
+
+                            <!-- 4) F4Wx Real Weather -->
+                            <Button x:Name="Launch_F4WX"
+                Grid.Column="3" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherButton}">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/F4WX.png" Style="{StaticResource LauncherIcon}"/>
+                                    <TextBlock x:Name="Label_F4WX"
+                           Text="F4Wx Real Weather"
+                           Style="{StaticResource LauncherLabel}"/>
+                                </StackPanel>
+                            </Button>
+
+                            <!-- 5) F4 RADAR C2 (AWACS) Tool -->
+                            <Button x:Name="Launch_F4RADAR"
+                Grid.Column="4" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherButton}">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/F4RADAR.png" Style="{StaticResource LauncherIcon}"/>
+                                    <TextBlock x:Name="Label_F4RADAR"
+                           Text="F4 RADAR C2 (AWACS) Tool"
+                           Style="{StaticResource LauncherLabel}"/>
+                                </StackPanel>
+                            </Button>
+                        </Grid>
+                    </Border>
 
                     <Border VerticalAlignment="Top" Height="Auto" Margin="794,60,24,0" Padding="10" Width="200" Style="{StaticResource LauncherStripBorder}">
                         <StackPanel Orientation="Vertical">
@@ -456,6 +448,13 @@
                               Style="{StaticResource LauncherToggleSwitch}" />
                         </StackPanel>
                     </Border>
+
+                    <CheckBox x:Name="ApplicationOverride" Content="Launch without applying overrides" HorizontalAlignment="Right" Margin="0,0,20,98" MinWidth="206" VerticalAlignment="Bottom" Background="#FFECFF71" Foreground="{StaticResource UiForegroundBrush}" />
+
+                    <ListBox x:Name="ListBox_BMS" SelectionChanged="ListBox_BMS_SelectionChanged" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="20,20,240,20" Width="220" Height="72" SelectionMode="Single" d:ItemsSource="{d:SampleData ItemCount=5}" Style="{StaticResource LauncherListBox}">
+                    </ListBox>
+
+                    <Button x:Name="Launch_BMS_Large" Content="LAUNCH" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" Controls:ControlsHelper.ContentCharacterCasing="Normal" HorizontalAlignment="Right" Margin="20,20,20,20" VerticalAlignment="Bottom" Width="208" Click="Launch_Click" Height="72" Background="#CC2494FF" BorderBrush="{x:Null}" FontSize="24" Grid.Row="1"/>
 
                 </Grid>
             </TabItem>

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -76,143 +76,88 @@
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
 
-                            <!-- Rows: Row 0 = icon baseline, Row 1 = captions -->
+                            <!-- Rows: Row 0 = icons, Row 1 = labels -->
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="32"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-
+                            
                             <Grid.Resources>
-                                <!-- Launcher button -->
-                                <Style x:Key="LauncherItemButton" TargetType="Button">
-                                    <!-- Prevent MahApps background states -->
-                                    <Setter Property="OverridesDefaultStyle" Value="True"/>
-                                    <Setter Property="Background" Value="Transparent"/>
-                                    <Setter Property="BorderThickness" Value="0"/>
-                                    <Setter Property="Cursor" Value="Hand"/>
-                                    <Setter Property="HorizontalAlignment" Value="Stretch"/>
-                                    <Setter Property="VerticalAlignment" Value="Stretch"/>
-                                    <Setter Property="Padding" Value="0"/>
-                                    <Setter Property="Template">
-                                        <Setter.Value>
-                                            <ControlTemplate TargetType="Button">
-                                                <!-- Just present the content -->
-                                                <ContentPresenter HorizontalAlignment="Center"
-                                      VerticalAlignment="Top"/>
-                                            </ControlTemplate>
-                                        </Setter.Value>
-                                    </Setter>
+                                <Style x:Key="LauncherButton" TargetType="Button" BasedOn="{StaticResource LauncherButtonBase}">
                                     <EventSetter Event="Click" Handler="Launch_Click"/>
                                     <EventSetter Event="MouseEnter" Handler="MouseEnterLauncher"/>
                                     <EventSetter Event="MouseLeave" Handler="MouseLeaveLauncher"/>
-                                </Style>
-
-                                <!-- Launcher caption -->
-                                <Style x:Key="LauncherCaptionText" TargetType="TextBlock">
-                                    <Setter Property="TextWrapping" Value="Wrap"/>
-                                    <Setter Property="TextAlignment" Value="Center"/>
-                                    <Setter Property="HorizontalAlignment" Value="Center"/>
-                                    <Setter Property="VerticalAlignment" Value="Top"/>
-                                    <Setter Property="Foreground" Value="#FFF0F0F0"/>
-                                    <Setter Property="FontWeight" Value="Bold"/>
-                                    <Setter Property="FontSize" Value="9"/>
-                                    <Setter Property="MaxWidth" Value="80"/>
-
-                                    <Style.Triggers>
-                                        <!-- Hovering the text itself -->
-                                        <Trigger Property="IsMouseOver" Value="True">
-                                            <Setter Property="Foreground" Value="{DynamicResource GridFocusedFgBrush}"/>
-                                        </Trigger>
-
-                                        <!-- Hovering anywhere on the parent Button (icon OR text) -->
-                                        <DataTrigger Value="True"
-                     Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=Button}}">
-                                            <Setter Property="Foreground" Value="{DynamicResource GridFocusedFgBrush}"/>
-                                        </DataTrigger>
-                                    </Style.Triggers>
                                 </Style>
                             </Grid.Resources>
 
                             <!-- 1) Update -->
                             <Button x:Name="Launch_UPD"
                 Grid.Column="0" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherItemButton}"
-                Click="Launch_Click">
+                Style="{StaticResource LauncherButton}">
                                 <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/UPD.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <Image Source="/Resources/UPD.png" Style="{StaticResource LauncherIcon}"/>
                                     <TextBlock x:Name="Label_UPD"
                            Text="Update"
-                           Style="{StaticResource LauncherCaptionText}"
-                           Margin="0,4,0,0"/>
+                           Style="{StaticResource LauncherLabel}"/>
                                 </StackPanel>
                             </Button>
 
                             <!-- 2) Config -->
                             <Button x:Name="Launch_CFG"
                 Grid.Column="1" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherItemButton}"
-                Click="Launch_Click">
+                Style="{StaticResource LauncherButton}">
                                 <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/CFG.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <Image Source="/Resources/CFG.png" Style="{StaticResource LauncherIcon}"/>
                                     <TextBlock x:Name="Label_CFG"
                            Text="Config"
-                           Style="{StaticResource LauncherCaptionText}"
-                           Margin="0,4,0,0"/>
+                           Style="{StaticResource LauncherLabel}"/>
                                 </StackPanel>
                             </Button>
 
                             <!-- 3) Display Config -->
                             <Button x:Name="Launch_MMC"
                 Grid.Column="2" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherItemButton}"
-                Click="Launch_Click">
+                Style="{StaticResource LauncherButton}">
                                 <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/BmsMultiMon.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <Image Source="/Resources/BmsMultiMon.png" Style="{StaticResource LauncherIcon}"/>
                                     <TextBlock x:Name="Label_MMC"
                            Text="Display Config"
-                           Style="{StaticResource LauncherCaptionText}"
-                           Margin="0,4,0,0"/>
+                           Style="{StaticResource LauncherLabel}"/>
                                 </StackPanel>
                             </Button>
 
                             <!-- 4) RTT Client -->
                             <Button x:Name="Launch_RTTC"
                 Grid.Column="3" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherItemButton}"
-                Click="Launch_Click">
+                Style="{StaticResource LauncherButton}">
                                 <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/RTTClient64.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <Image Source="/Resources/RTTClient64.png" Style="{StaticResource LauncherIcon}"/>
                                     <TextBlock x:Name="Label_RTTC"
                            Text="RTT Client"
-                           Style="{StaticResource LauncherCaptionText}"
-                           Margin="0,4,0,0"/>
+                           Style="{StaticResource LauncherLabel}"/>
                                 </StackPanel>
                             </Button>
 
                             <!-- 5) RTT Server -->
                             <Button x:Name="Launch_RTTS"
                 Grid.Column="4" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherItemButton}"
-                Click="Launch_Click">
+                Style="{StaticResource LauncherButton}">
                                 <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/RTTServer64.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <Image Source="/Resources/RTTServer64.png" Style="{StaticResource LauncherIcon}"/>
                                     <TextBlock x:Name="Label_RTTS"
                            Text="RTT Server"
-                           Style="{StaticResource LauncherCaptionText}"
-                           Margin="0,4,0,0"/>
+                           Style="{StaticResource LauncherLabel}"/>
                                 </StackPanel>
                             </Button>
 
                             <!-- 6) IVC Client (MP Radio) -->
                             <Button x:Name="Launch_IVCC"
                 Grid.Column="5" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherItemButton}"
-                Click="Launch_Click">
+                Style="{StaticResource LauncherButton}">
                                 <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/IVCC.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <Image Source="/Resources/IVCC.png" Style="{StaticResource LauncherIcon}"/>
                                     <TextBlock x:Name="Label_IVCC"
-                           Style="{StaticResource LauncherCaptionText}"
-                           Margin="0,4,0,0">
+                           Style="{StaticResource LauncherLabel}">
                     <Run Text="IVC Client"/>
                     <LineBreak/>
                     <Run Text="(MP Radio)"/>
@@ -223,13 +168,11 @@
                             <!-- 7) IVC Server (MP Radio) -->
                             <Button x:Name="Launch_IVCS"
                 Grid.Column="6" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherItemButton}"
-                Click="Launch_Click">
+                Style="{StaticResource LauncherButton}">
                                 <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/IVCS.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <Image Source="/Resources/IVCS.png" Style="{StaticResource LauncherIcon}"/>
                                     <TextBlock x:Name="Label_IVCS"
-                           Style="{StaticResource LauncherCaptionText}"
-                           Margin="0,4,0,0">
+                           Style="{StaticResource LauncherLabel}">
                     <Run Text="IVC Server"/>
                     <LineBreak/>
                     <Run Text="(MP Radio)"/>
@@ -240,13 +183,11 @@
                             <!-- 8) Avionics Configurator -->
                             <Button x:Name="Launch_AVC"
                 Grid.Column="7" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherItemButton}"
-                Click="Launch_Click">
+                Style="{StaticResource LauncherButton}">
                                 <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/AVC.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <Image Source="/Resources/AVC.png" Style="{StaticResource LauncherIcon}"/>
                                     <TextBlock x:Name="Label_AVC"
-                           Style="{StaticResource LauncherCaptionText}"
-                           Margin="0,4,0,0">
+                           Style="{StaticResource LauncherLabel}">
                     <Run Text="Avionics"/>
                     <LineBreak/>
                     <Run Text="Configurator"/>
@@ -257,14 +198,12 @@
                             <!-- 9) Editor -->
                             <Button x:Name="Launch_EDIT"
                 Grid.Column="8" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherItemButton}"
-                Click="Launch_Click">
+                Style="{StaticResource LauncherButton}">
                                 <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/EDIT.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <Image Source="/Resources/EDIT.png" Style="{StaticResource LauncherIcon}"/>
                                     <TextBlock x:Name="Label_EDIT"
                            Text="Editor"
-                           Style="{StaticResource LauncherCaptionText}"
-                           Margin="0,4,0,0"/>
+                           Style="{StaticResource LauncherLabel}"/>
                                 </StackPanel>
                             </Button>
                         </Grid>
@@ -289,131 +228,77 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
 
-                            <!-- Rows: Row 0 = icon baseline, Row 1 = captions -->
+                            <!-- Rows: Row 0 = icons, Row 1 = labels -->
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="32"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
 
                             <Grid.Resources>
-                                <!-- Launcher button -->
-                                <Style x:Key="LauncherItemButton" TargetType="Button">
-                                    <!-- Prevent MahApps background states -->
-                                    <Setter Property="OverridesDefaultStyle" Value="True"/>
-                                    <Setter Property="Background" Value="Transparent"/>
-                                    <Setter Property="BorderThickness" Value="0"/>
-                                    <Setter Property="Cursor" Value="Hand"/>
-                                    <Setter Property="HorizontalAlignment" Value="Stretch"/>
-                                    <Setter Property="VerticalAlignment" Value="Stretch"/>
-                                    <Setter Property="Padding" Value="0"/>
-                                    <Setter Property="Template">
-                                        <Setter.Value>
-                                            <ControlTemplate TargetType="Button">
-                                                <!-- Just present the content -->
-                                                <ContentPresenter HorizontalAlignment="Center"
-                                      VerticalAlignment="Top"/>
-                                            </ControlTemplate>
-                                        </Setter.Value>
-                                    </Setter>
-                                    <EventSetter Event="Click" Handler="Launch_Click"/>
+                                <Style x:Key="LauncherButton" TargetType="Button" BasedOn="{StaticResource LauncherButtonBase}">
+                                    <EventSetter Event="Click" Handler="Launch_Third"/>
                                     <EventSetter Event="MouseEnter" Handler="MouseEnterLauncher"/>
                                     <EventSetter Event="MouseLeave" Handler="MouseLeaveLauncher"/>
                                 </Style>
-
-                                <!-- Launcher caption -->
-                                <Style x:Key="LauncherCaptionText" TargetType="TextBlock">
-                                    <Setter Property="TextWrapping" Value="Wrap"/>
-                                    <Setter Property="TextAlignment" Value="Center"/>
-                                    <Setter Property="HorizontalAlignment" Value="Center"/>
-                                    <Setter Property="VerticalAlignment" Value="Top"/>
-                                    <Setter Property="Foreground" Value="#FFF0F0F0"/>
-                                    <Setter Property="FontWeight" Value="Bold"/>
-                                    <Setter Property="FontSize" Value="9"/>
-                                    <Setter Property="MaxWidth" Value="80"/>
-
-                                    <Style.Triggers>
-                                        <!-- Hovering the text itself -->
-                                        <Trigger Property="IsMouseOver" Value="True">
-                                            <Setter Property="Foreground" Value="{DynamicResource GridFocusedFgBrush}"/>
-                                        </Trigger>
-
-                                        <!-- Hovering anywhere on the parent Button (icon OR text) -->
-                                        <DataTrigger Value="True"
-                     Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=Button}}">
-                                            <Setter Property="Foreground" Value="{DynamicResource GridFocusedFgBrush}"/>
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
                             </Grid.Resources>
-
 
                             <!-- 1) Weapon Delivery Planner -->
                             <Button x:Name="Launch_WDP"
                 Grid.Column="0" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherItemButton}"
-                Click="Launch_Third">
+                Style="{StaticResource LauncherButton}">
                                 <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/WDP.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <Image Source="/Resources/WDP.png" Style="{StaticResource LauncherIcon}"/>
                                     <TextBlock x:Name="Label_WDP"
                            Text="Weapon Delivery Planner"
-                           Style="{StaticResource LauncherCaptionText}"
-                           Margin="0,4,0,0"/>
+                           Style="{StaticResource LauncherLabel}"/>
                                 </StackPanel>
                             </Button>
 
                             <!-- 2) Mission Commander -->
                             <Button x:Name="Launch_MC"
                 Grid.Column="1" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherItemButton}"
-                Click="Launch_Third">
+                Style="{StaticResource LauncherButton}">
                                 <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/MC.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <Image Source="/Resources/MC.png" Style="{StaticResource LauncherIcon}"/>
                                     <TextBlock x:Name="Label_MC"
                            Text="Mission Commander"
-                           Style="{StaticResource LauncherCaptionText}"
-                           Margin="0,4,0,0"/>
+                           Style="{StaticResource LauncherLabel}"/>
                                 </StackPanel>
                             </Button>
 
                             <!-- 3) Weather Commander -->
                             <Button x:Name="Launch_WC"
                 Grid.Column="2" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherItemButton}"
-                Click="Launch_Third">
+                Style="{StaticResource LauncherButton}">
                                 <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/WC.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <Image Source="/Resources/WC.png" Style="{StaticResource LauncherIcon}"/>
                                     <TextBlock x:Name="Label_WC"
                            Text="Weather Commander"
-                           Style="{StaticResource LauncherCaptionText}"
-                           Margin="0,4,0,0"/>
+                           Style="{StaticResource LauncherLabel}"/>
                                 </StackPanel>
                             </Button>
 
                             <!-- 4) F4Wx Real Weather -->
                             <Button x:Name="Launch_F4WX"
                 Grid.Column="3" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherItemButton}"
-                Click="Launch_Third">
+                Style="{StaticResource LauncherButton}">
                                 <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/F4WX.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <Image Source="/Resources/F4WX.png" Style="{StaticResource LauncherIcon}"/>
                                     <TextBlock x:Name="Label_F4WX"
                            Text="F4Wx Real Weather"
-                           Style="{StaticResource LauncherCaptionText}"
-                           Margin="0,4,0,0"/>
+                           Style="{StaticResource LauncherLabel}"/>
                                 </StackPanel>
                             </Button>
 
                             <!-- 5) F4 RADAR C2 (AWACS) Tool -->
                             <Button x:Name="Launch_F4RADAR"
                 Grid.Column="4" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherItemButton}"
-                Click="Launch_Third">
+                Style="{StaticResource LauncherButton}">
                                 <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/F4RADAR.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <Image Source="/Resources/F4RADAR.png" Style="{StaticResource LauncherIcon}"/>
                                     <TextBlock x:Name="Label_F4RADAR"
                            Text="F4 RADAR C2 (AWACS) Tool"
-                           Style="{StaticResource LauncherCaptionText}"
-                           Margin="0,2,0,0"/>
+                           Style="{StaticResource LauncherLabel}"/>
                                 </StackPanel>
                             </Button>
                         </Grid>
@@ -455,8 +340,6 @@
                         <!-- Theater -->
                         <Label Grid.Row="0" Grid.Column="0"
            Content="Theater :"
-           HorizontalAlignment="Left"
-           VerticalAlignment="Center"
            Style="{StaticResource LauncherTitle}"/>
                         <ComboBox x:Name="Dropdown_TheaterList"
               Grid.Row="0" Grid.Column="1"
@@ -470,9 +353,6 @@
                         <!-- Documentation -->
                         <Label Grid.Row="2" Grid.Column="0"
            Content="Documentation :"
-           HorizontalAlignment="Left"
-           VerticalAlignment="Center"
-           FontWeight="Bold"
            Style="{StaticResource LauncherTitle}"/>
                         <Button x:Name="OpenDocs"
             Grid.Row="2" Grid.Column="1"
@@ -490,9 +370,6 @@
                         <Label x:Name="Label_VR"
            Grid.Row="4" Grid.Column="0"
            Content="Virtual / Mixed Reality :"
-           HorizontalAlignment="Left"
-           VerticalAlignment="Center"
-           FontWeight="Bold"
            Style="{StaticResource LauncherTitle}"/>
 
                         <!-- Radio columns used in both rows (shared sizes) -->
@@ -531,9 +408,6 @@
                         <Label x:Name="Label_RTT"
            Grid.Row="6" Grid.Column="0"
            Content="Export RTT Textures:"
-           HorizontalAlignment="Left"
-           VerticalAlignment="Center"
-           FontWeight="Bold"
            Style="{StaticResource LauncherTitle}"/>
 
                         <!-- Radio columns used in both rows (shared sizes) -->
@@ -565,20 +439,21 @@
 
                     </Grid>
 
-                    <Label Content="News" HorizontalAlignment="Left" Margin="48,10,0,0" VerticalAlignment="Top" FontSize="24" FontWeight="Bold" FontStyle="Italic"/>
+                    <Label Content="News" HorizontalAlignment="Left" Margin="48,10,0,0" VerticalAlignment="Top" FontSize="24" FontWeight="Bold" FontStyle="Italic" Foreground="{StaticResource UiForegroundBrush}"/>
                     <ScrollViewer x:Name ="LogTextScroll" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Margin="48,60,460,350" Background="#5000">
                         <TextBlock x:Name="News" HorizontalAlignment="Left" TextWrapping="Wrap" Text="" VerticalAlignment="Top" Height="Auto" Width="380" Margin="20,20,0,0" />
                     </ScrollViewer>
 
-                    <Border HorizontalAlignment="Right" VerticalAlignment="Top" Height="Auto" Margin="480,60,20,20" Padding="10" Background="#3000" Width="200">
+                    <Border VerticalAlignment="Top" Height="Auto" Margin="794,60,24,0" Padding="10" Width="200" Style="{StaticResource LauncherStripBorder}">
                         <StackPanel Orientation="Vertical">
-                            <Label Content="Launch Options :" HorizontalAlignment="Left" Margin="10" FontSize="13" FontWeight="Bold" Style="{StaticResource LauncherTitle}" />
-                            <Controls:ToggleSwitch x:Name="CMD_ACMI" OnContent="ACMI On" OffContent="ACMI Off" HorizontalAlignment="Right" FontSize="11" Margin="10" Style="{StaticResource LauncherToggleSwitch}" />
-                            <Controls:ToggleSwitch x:Name="CMD_WINDOW" OnContent="WINDOW On" OffContent="WINDOW Off" HorizontalAlignment="Right" FontSize="11" Margin="10" Style="{StaticResource LauncherToggleSwitch}" />
-                            <Controls:ToggleSwitch x:Name="CMD_NOMOVIE" OnContent="NOMOVIE On" OffContent="NOMOVIE Off" HorizontalAlignment="Right" FontSize="11" Margin="10" Style="{StaticResource LauncherToggleSwitch}" />
-                            <Controls:ToggleSwitch x:Name="CMD_EF" OnContent="EYEFLY On" OffContent="EYEFLY Off" HorizontalAlignment="Right" FontSize="11" Margin="10" Style="{StaticResource LauncherToggleSwitch}" />
-                            <Controls:ToggleSwitch x:Name="CMD_MONO" OnContent="DEBUG On" OffContent="DEBUG Off" HorizontalAlignment="Right" FontSize="11" Margin="10" Style="{StaticResource LauncherToggleSwitch}" />
-                            <Controls:ToggleSwitch x:Name="AB_Test" Visibility="Hidden" OffContent="A" OnContent="B" Margin="10" HorizontalAlignment="Right" Style="{StaticResource LauncherToggleSwitch}" />
+                            <Label Content="Launch Options :" Margin="10" FontSize="13" Style="{StaticResource LauncherTitle}" />
+                            <Controls:ToggleSwitch x:Name="CMD_ACMI" OnContent="ACMI On" OffContent="ACMI Off"  Style="{StaticResource LauncherToggleSwitch}" />
+                            <Controls:ToggleSwitch x:Name="CMD_WINDOW" OnContent="WINDOW On" OffContent="WINDOW Off" Style="{StaticResource LauncherToggleSwitch}" />
+                            <Controls:ToggleSwitch x:Name="CMD_NOMOVIE" OnContent="NOMOVIE On" OffContent="NOMOVIE Off" Style="{StaticResource LauncherToggleSwitch}" />
+                            <Controls:ToggleSwitch x:Name="CMD_EF" OnContent="EYEFLY On" OffContent="EYEFLY Off" Style="{StaticResource LauncherToggleSwitch}" />
+                            <Controls:ToggleSwitch x:Name="CMD_MONO" OnContent="DEBUG On" OffContent="DEBUG Off" Style="{StaticResource LauncherToggleSwitch}" />
+                            <Controls:ToggleSwitch x:Name="AB_Test" Visibility="Hidden" OffContent="A" OnContent="B"
+                              Style="{StaticResource LauncherToggleSwitch}" />
                         </StackPanel>
                     </Border>
 

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -424,19 +424,145 @@
                     <ListBox x:Name="ListBox_BMS" SelectionChanged="ListBox_BMS_SelectionChanged" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="20,20,240,20" Width="220" Height="72" SelectionMode="Single" d:ItemsSource="{d:SampleData ItemCount=5}" Style="{StaticResource LauncherListBox}">
                     </ListBox>
 
-                    <Grid HorizontalAlignment="Left" Height="127" Margin="46,0,0,191" VerticalAlignment="Bottom" Width="953">
-                        <Label Content="Theater :" HorizontalAlignment="Left" VerticalAlignment="Top" Style="{StaticResource LauncherTitle}"/>
-                        <ComboBox x:Name="Dropdown_TheaterList" Background="#F0F0F0" Foreground="#FF191919" HorizontalAlignment="Left" Margin="180,4,0,0" VerticalAlignment="Top" Width="239" SelectionChanged="Dropdown_TheaterList_SelectionChanged"/>
-                        <Label Content="Documentation :" HorizontalAlignment="Left" Margin="0,32,0,0" VerticalAlignment="Top" FontWeight="Bold" Style="{StaticResource LauncherTitle}" />
-                        <Button x:Name="OpenDocs" Content="Open Docs Folder" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" Controls:ControlsHelper.ContentCharacterCasing="Normal" HorizontalAlignment="Left" Margin="180,37,0,0" VerticalAlignment="Top" Width="141" Click="OpenDocs_Click" FontSize="10" Height="10"/>
-                        <Label x:Name="Label_VR" Content="Virtual / Mixed Reality :" HorizontalAlignment="Left" Margin="0,64,0,0" VerticalAlignment="Top" FontWeight="Bold" Style="{StaticResource LauncherTitle}" />
-                        <RadioButton x:Name="VR_NoVR" GroupName="VR" Content="No VR" HorizontalAlignment="Left" Margin="180,70,0,0" VerticalAlignment="Top" Style="{StaticResource LauncherRadioButton}"/>
-                        <RadioButton x:Name="VR_SteamVR" GroupName="VR" Content="SteamVR" HorizontalAlignment="Left" Margin="250,70,0,0" VerticalAlignment="Top" Click="Misc_VR_Click" Style="{StaticResource LauncherRadioButton}"/>
-                        <RadioButton x:Name="VR_OpenXR" GroupName="VR" Content="OpenXR" HorizontalAlignment="Left" Margin="329,70,0,0" VerticalAlignment="Top" Style="{StaticResource LauncherRadioButton}"/>
+                    <Grid HorizontalAlignment="Left"
+          VerticalAlignment="Bottom"
+          Width="480"
+          Height="Auto"
+          Margin="46,0,0,191"
+          Grid.IsSharedSizeScope="True">
 
-                        <Label x:Name="Label_RTT" Content="Export RTT Textures:" HorizontalAlignment="Left" Margin="0,94,0,0" VerticalAlignment="Top" FontWeight="Bold" Style="{StaticResource LauncherTitle}" />
-                        <RadioButton x:Name="RTT_Disable" GroupName="RTT" Content="Disable" HorizontalAlignment="Left" Margin="180,100,0,0" VerticalAlignment="Top" Style="{StaticResource LauncherRadioButton}"/>
-                        <RadioButton x:Name="RTT_Enable" GroupName="RTT" Content="Enable" HorizontalAlignment="Left" Margin="250,100,0,0" VerticalAlignment="Top" Style="{StaticResource LauncherRadioButton}"/>
+                        <!-- Two columns: labels (fixed) + inputs (stretch) -->
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="180"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <!-- Rows: content rows with small spacer rows between -->
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <!-- 0: Theater -->
+                            <RowDefinition Height="8"/>
+                            <RowDefinition Height="Auto"/>
+                            <!-- 2: Documentation -->
+                            <RowDefinition Height="8"/>
+                            <RowDefinition Height="Auto"/>
+                            <!-- 4: VR -->
+                            <RowDefinition Height="8"/>
+                            <RowDefinition Height="Auto"/>
+                            <!-- 6: RTT -->
+                        </Grid.RowDefinitions>
+
+                        <!-- Theater -->
+                        <Label Grid.Row="0" Grid.Column="0"
+           Content="Theater :"
+           HorizontalAlignment="Left"
+           VerticalAlignment="Center"
+           Style="{StaticResource LauncherTitle}"/>
+                        <ComboBox x:Name="Dropdown_TheaterList"
+              Grid.Row="0" Grid.Column="1"
+              Width="239"
+              HorizontalAlignment="Left"
+              VerticalAlignment="Center"
+              Background="#F0F0F0"
+              Foreground="#FF191919"
+              SelectionChanged="Dropdown_TheaterList_SelectionChanged"/>
+
+                        <!-- Documentation -->
+                        <Label Grid.Row="2" Grid.Column="0"
+           Content="Documentation :"
+           HorizontalAlignment="Left"
+           VerticalAlignment="Center"
+           FontWeight="Bold"
+           Style="{StaticResource LauncherTitle}"/>
+                        <Button x:Name="OpenDocs"
+            Grid.Row="2" Grid.Column="1"
+            Width="141"
+            Height="20"
+            HorizontalAlignment="Left"
+            VerticalAlignment="Center"
+            Content="Open Docs Folder"
+            FontSize="10"
+            Click="OpenDocs_Click"
+            Style="{StaticResource MahApps.Styles.Button.Square.Accent}"
+            Controls:ControlsHelper.ContentCharacterCasing="Normal"/>
+
+                        <!-- Virtual / Mixed Reality -->
+                        <Label x:Name="Label_VR"
+           Grid.Row="4" Grid.Column="0"
+           Content="Virtual / Mixed Reality :"
+           HorizontalAlignment="Left"
+           VerticalAlignment="Center"
+           FontWeight="Bold"
+           Style="{StaticResource LauncherTitle}"/>
+
+                        <!-- Radio columns used in both rows (shared sizes) -->
+                        <Grid Grid.Row="4" Grid.Column="1"
+          HorizontalAlignment="Left"
+          VerticalAlignment="Center">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="RB1"/>
+                                <ColumnDefinition Width="24"  SharedSizeGroup="SP"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="RB2"/>
+                                <ColumnDefinition Width="24"  SharedSizeGroup="SP"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="RB3"/>
+                            </Grid.ColumnDefinitions>
+
+                            <RadioButton x:Name="VR_NoVR"
+                     Grid.Column="0"
+                     GroupName="VR"
+                     Content="No VR"
+                     Style="{StaticResource LauncherRadioButton}"/>
+
+                            <RadioButton x:Name="VR_SteamVR"
+                     Grid.Column="2"
+                     GroupName="VR"
+                     Content="SteamVR"
+                     Style="{StaticResource LauncherRadioButton}"
+                     Click="Misc_VR_Click"/>
+
+                            <RadioButton x:Name="VR_OpenXR"
+                     Grid.Column="4"
+                     GroupName="VR"
+                     Content="OpenXR"
+                     Style="{StaticResource LauncherRadioButton}"/>
+                        </Grid>
+
+                        <!-- Export RTT Textures -->
+                        <Label x:Name="Label_RTT"
+           Grid.Row="6" Grid.Column="0"
+           Content="Export RTT Textures:"
+           HorizontalAlignment="Left"
+           VerticalAlignment="Center"
+           FontWeight="Bold"
+           Style="{StaticResource LauncherTitle}"/>
+
+                        <!-- Radio columns used in both rows (shared sizes) -->
+                        <Grid Grid.Row="6" Grid.Column="1"
+          HorizontalAlignment="Left"
+          VerticalAlignment="Center">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="RB1"/>
+                                <ColumnDefinition Width="24"  SharedSizeGroup="SP"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="RB2"/>
+                                <ColumnDefinition Width="24"  SharedSizeGroup="SP"/>
+                                <ColumnDefinition Width="Auto" SharedSizeGroup="RB3"/>
+                            </Grid.ColumnDefinitions>
+
+                            <RadioButton x:Name="RTT_Disable"
+                     Grid.Column="0"
+                     GroupName="RTT"
+                     Content="Disable"
+                     Style="{StaticResource LauncherRadioButton}"/>
+
+                            <RadioButton x:Name="RTT_Enable"
+                     Grid.Column="2"
+                     GroupName="RTT"
+                     Content="Enable"
+                     Style="{StaticResource LauncherRadioButton}"/>
+
+                            <!-- Column 4 (RB3) intentionally empty; reserves the same width as VRs third radio -->
+                        </Grid>
+
                     </Grid>
 
                     <Label Content="News" HorizontalAlignment="Left" Margin="48,10,0,0" VerticalAlignment="Top" FontSize="24" FontWeight="Bold" FontStyle="Italic"/>

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -51,173 +51,374 @@
         <TabControl x:Name="LargeTab" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" SelectionChanged="TabControl_SelectionChanged" Margin="0,64,0.333,0.334" Background="{x:Null}" Grid.RowSpan="2">
             <TabItem Header="LAUNCHER" x:Name="Tab_Launcher" Margin="535,-40,-535.333,40.333" Style="{StaticResource TabHeader}">
                 <Grid>
-                    <Border BorderThickness="1" HorizontalAlignment="Left" Height="72" Width="638" Margin="48,0,0,97" VerticalAlignment="Bottom" Style="{StaticResource LauncherStripBorder}">
-                        <Grid HorizontalAlignment="Stretch" Height="auto" Margin="0,0,0,0" VerticalAlignment="Stretch" Width="auto">
+
+                    <CheckBox x:Name="ApplicationOverride" Content="Launch without applying overrides" HorizontalAlignment="Right" Margin="0,0,20,98" MinWidth="206" VerticalAlignment="Bottom" Background="#FFECFF71" Foreground="{StaticResource UiForegroundBrush}" />
+
+                    <Border BorderThickness="1"
+        HorizontalAlignment="Left"
+        Height="72"
+        Width="638"
+        Margin="48,0,0,97"
+        VerticalAlignment="Bottom"
+        Style="{StaticResource LauncherStripBorder}">
+
+                        <Grid VerticalAlignment="Center">
+                            <!-- 9 columns -->
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+
+                            <!-- Rows: Row 0 = icon baseline, Row 1 = captions -->
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="32"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+
                             <Grid.Resources>
-                                <Style TargetType="Button">
-                                    <Setter Property="BorderThickness" Value="10" />
-                                    <Setter Property="BorderBrush" Value="Black" />
-                                    <Setter Property="HorizontalAlignment" Value="Left" />
-                                    <Setter Property="VerticalAlignment" Value="Bottom" />
-                                    <Setter Property="Width" Value="32" />
-                                    <Setter Property="Height" Value="32" />
+                                <!-- Launcher button -->
+                                <Style x:Key="LauncherItemButton" TargetType="Button">
+                                    <!-- Prevent MahApps background states -->
+                                    <Setter Property="OverridesDefaultStyle" Value="True"/>
+                                    <Setter Property="Background" Value="Transparent"/>
+                                    <Setter Property="BorderThickness" Value="0"/>
+                                    <Setter Property="Cursor" Value="Hand"/>
+                                    <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                                    <Setter Property="VerticalAlignment" Value="Stretch"/>
+                                    <Setter Property="Padding" Value="0"/>
+                                    <Setter Property="Template">
+                                        <Setter.Value>
+                                            <ControlTemplate TargetType="Button">
+                                                <!-- Just present the content -->
+                                                <ContentPresenter HorizontalAlignment="Center"
+                                      VerticalAlignment="Top"/>
+                                            </ControlTemplate>
+                                        </Setter.Value>
+                                    </Setter>
                                     <EventSetter Event="Click" Handler="Launch_Click"/>
                                     <EventSetter Event="MouseEnter" Handler="MouseEnterLauncher"/>
                                     <EventSetter Event="MouseLeave" Handler="MouseLeaveLauncher"/>
                                 </Style>
-                                <Style TargetType="Label">
-                                    <Setter Property="HorizontalAlignment" Value="Left" />
-                                    <Setter Property="VerticalAlignment" Value="Bottom" />
-                                    <Setter Property="Foreground" Value="#FFF0F0F0" />
-                                    <Setter Property="HorizontalContentAlignment" Value="Center" />
-                                    <Setter Property="FontWeight" Value="Bold" />
-                                    <Setter Property="FontSize" Value="8" />
+
+                                <!-- Launcher caption -->
+                                <Style x:Key="LauncherCaptionText" TargetType="TextBlock">
+                                    <Setter Property="TextWrapping" Value="Wrap"/>
+                                    <Setter Property="TextAlignment" Value="Center"/>
+                                    <Setter Property="HorizontalAlignment" Value="Center"/>
+                                    <Setter Property="VerticalAlignment" Value="Top"/>
+                                    <Setter Property="Foreground" Value="#FFF0F0F0"/>
+                                    <Setter Property="FontWeight" Value="Bold"/>
+                                    <Setter Property="FontSize" Value="9"/>
+                                    <Setter Property="MaxWidth" Value="80"/>
+
+                                    <Style.Triggers>
+                                        <!-- Hovering the text itself -->
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter Property="Foreground" Value="{DynamicResource GridFocusedFgBrush}"/>
+                                        </Trigger>
+
+                                        <!-- Hovering anywhere on the parent Button (icon OR text) -->
+                                        <DataTrigger Value="True"
+                     Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=Button}}">
+                                            <Setter Property="Foreground" Value="{DynamicResource GridFocusedFgBrush}"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
                                 </Style>
                             </Grid.Resources>
 
-                            <Button x:Name="Launch_UPD" Margin="20,0,0,33.333">
-                                <Button.Template>
-                                    <ControlTemplate>
-                                        <Image Source="/Resources/UPD.png"/>
-                                    </ControlTemplate>
-                                </Button.Template>
+                            <!-- 1) Update -->
+                            <Button x:Name="Launch_UPD"
+                Grid.Column="0" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherItemButton}"
+                Click="Launch_Click">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/UPD.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <TextBlock x:Name="Label_UPD"
+                           Text="Update"
+                           Style="{StaticResource LauncherCaptionText}"
+                           Margin="0,4,0,0"/>
+                                </StackPanel>
                             </Button>
-                            <Button x:Name="Launch_CFG" Margin="90,0,0,33.333">
-                                <Button.Template>
-                                    <ControlTemplate>
-                                        <Image Source="/Resources/CFG.png"/>
-                                    </ControlTemplate>
-                                </Button.Template>
+
+                            <!-- 2) Config -->
+                            <Button x:Name="Launch_CFG"
+                Grid.Column="1" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherItemButton}"
+                Click="Launch_Click">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/CFG.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <TextBlock x:Name="Label_CFG"
+                           Text="Config"
+                           Style="{StaticResource LauncherCaptionText}"
+                           Margin="0,4,0,0"/>
+                                </StackPanel>
                             </Button>
-                            <Button x:Name="Launch_MMC" Margin="160,0,0,33.333">
-                                <Button.Template>
-                                    <ControlTemplate>
-                                        <Image Source="/Resources/BmsMultiMon.png"/>
-                                    </ControlTemplate>
-                                </Button.Template>
+
+                            <!-- 3) Display Config -->
+                            <Button x:Name="Launch_MMC"
+                Grid.Column="2" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherItemButton}"
+                Click="Launch_Click">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/BmsMultiMon.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <TextBlock x:Name="Label_MMC"
+                           Text="Display Config"
+                           Style="{StaticResource LauncherCaptionText}"
+                           Margin="0,4,0,0"/>
+                                </StackPanel>
                             </Button>
-                            <Button x:Name="Launch_RTTC" Margin="230,0,0,33.333">
-                                <Button.Template>
-                                    <ControlTemplate>
-                                        <Image Source="/Resources/RTTClient64.png"/>
-                                    </ControlTemplate>
-                                </Button.Template>
+
+                            <!-- 4) RTT Client -->
+                            <Button x:Name="Launch_RTTC"
+                Grid.Column="3" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherItemButton}"
+                Click="Launch_Click">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/RTTClient64.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <TextBlock x:Name="Label_RTTC"
+                           Text="RTT Client"
+                           Style="{StaticResource LauncherCaptionText}"
+                           Margin="0,4,0,0"/>
+                                </StackPanel>
                             </Button>
-                            <Button x:Name="Launch_RTTS" Margin="300,0,0,33.333">
-                                <Button.Template>
-                                    <ControlTemplate>
-                                        <Image Source="/Resources/RTTServer64.png"/>
-                                    </ControlTemplate>
-                                </Button.Template>
+
+                            <!-- 5) RTT Server -->
+                            <Button x:Name="Launch_RTTS"
+                Grid.Column="4" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherItemButton}"
+                Click="Launch_Click">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/RTTServer64.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <TextBlock x:Name="Label_RTTS"
+                           Text="RTT Server"
+                           Style="{StaticResource LauncherCaptionText}"
+                           Margin="0,4,0,0"/>
+                                </StackPanel>
                             </Button>
-                            <Button x:Name="Launch_IVCC" Margin="370,0,0,33.333">
-                                <Button.Template>
-                                    <ControlTemplate>
-                                        <Image Source="/Resources/IVCC.png"/>
-                                    </ControlTemplate>
-                                </Button.Template>
+
+                            <!-- 6) IVC Client (MP Radio) -->
+                            <Button x:Name="Launch_IVCC"
+                Grid.Column="5" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherItemButton}"
+                Click="Launch_Click">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/IVCC.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <TextBlock x:Name="Label_IVCC"
+                           Style="{StaticResource LauncherCaptionText}"
+                           Margin="0,4,0,0">
+                    <Run Text="IVC Client"/>
+                    <LineBreak/>
+                    <Run Text="(MP Radio)"/>
+                                    </TextBlock>
+                                </StackPanel>
                             </Button>
-                            <Button x:Name="Launch_IVCS" Margin="440,0,0,33.333">
-                                <Button.Template>
-                                    <ControlTemplate>
-                                        <Image Source="/Resources/IVCS.png"/>
-                                    </ControlTemplate>
-                                </Button.Template>
+
+                            <!-- 7) IVC Server (MP Radio) -->
+                            <Button x:Name="Launch_IVCS"
+                Grid.Column="6" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherItemButton}"
+                Click="Launch_Click">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/IVCS.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <TextBlock x:Name="Label_IVCS"
+                           Style="{StaticResource LauncherCaptionText}"
+                           Margin="0,4,0,0">
+                    <Run Text="IVC Server"/>
+                    <LineBreak/>
+                    <Run Text="(MP Radio)"/>
+                                    </TextBlock>
+                                </StackPanel>
                             </Button>
-                            <Button x:Name="Launch_AVC" Margin="510,0,0,33.333">
-                                <Button.Template>
-                                    <ControlTemplate>
-                                        <Image Source="/Resources/AVC.png"/>
-                                    </ControlTemplate>
-                                </Button.Template>
+
+                            <!-- 8) Avionics Configurator -->
+                            <Button x:Name="Launch_AVC"
+                Grid.Column="7" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherItemButton}"
+                Click="Launch_Click">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/AVC.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <TextBlock x:Name="Label_AVC"
+                           Style="{StaticResource LauncherCaptionText}"
+                           Margin="0,4,0,0">
+                    <Run Text="Avionics"/>
+                    <LineBreak/>
+                    <Run Text="Configurator"/>
+                                    </TextBlock>
+                                </StackPanel>
                             </Button>
-                            <Button x:Name="Launch_EDIT" Margin="580,0,0,33.333">
-                                <Button.Template>
-                                    <ControlTemplate>
-                                        <Image Source="/Resources/EDIT.png"/>
-                                    </ControlTemplate>
-                                </Button.Template>
+
+                            <!-- 9) Editor -->
+                            <Button x:Name="Launch_EDIT"
+                Grid.Column="8" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherItemButton}"
+                Click="Launch_Click">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/EDIT.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <TextBlock x:Name="Label_EDIT"
+                           Text="Editor"
+                           Style="{StaticResource LauncherCaptionText}"
+                           Margin="0,4,0,0"/>
+                                </StackPanel>
                             </Button>
-                            <Label x:Name="Label_UPD" Content="Update&#xD;&#xA;" Margin="18,0,0,0"/>
-                            <Label x:Name="Label_CFG" Content="Config&#xD;&#xA;" Margin="88,0,0,0"/>
-                            <Label x:Name="Label_MMC" Content="Display&#xD;&#xA;Config" Margin="158,0,0,0"/>
-                            <Label x:Name="Label_RTTC" Content="RTT Client&#xD;&#xA;" Margin="220,0,0,0"/>
-                            <Label x:Name="Label_RTTS" Content="RTT Server&#xD;&#xA;" Margin="290,0,0,0"/>
-                            <Label x:Name="Label_IVCC" Content="IVC Client&#xD;&#xA;(MP Radio)" Margin="361,0,0,0"/>
-                            <Label x:Name="Label_IVCS" Content="IVC Server&#xD;&#xA;(MP Radio)" Margin="428,0,0,0"/>
-                            <Label x:Name="Label_AVC" Content="Avionics&#xD;&#xA;Configurator" Margin="501,0,0,0"/>
-                            <Label x:Name="Label_EDIT" Content="Editor&#xD;&#xA;" Margin="575,0,0,0"/>
                         </Grid>
                     </Border>
-                    <CheckBox x:Name="ApplicationOverride" Content="Launch without applying overrides" HorizontalAlignment="Right" Margin="0,0,20,98" MinWidth="206" VerticalAlignment="Bottom" Background="#FFECFF71" Foreground="{StaticResource UiForegroundBrush}" />
 
-                    <Border BorderThickness="1" HorizontalAlignment="Left" Height="72" Margin="48,0,0,20" VerticalAlignment="Bottom" Width="480" Style="{StaticResource LauncherStripBorder}">
-                        <Grid HorizontalAlignment="Stretch" Height="auto" Margin="0,0,0,0" VerticalAlignment="Stretch" Width="auto">
+
+                    <Border BorderThickness="1"
+        HorizontalAlignment="Left"
+        Height="72"
+        Width="480"
+        Margin="48,0,0,20"
+        VerticalAlignment="Bottom"
+        Style="{StaticResource LauncherStripBorder}">
+
+                        <Grid VerticalAlignment="Center">
+                            <!-- 5 columns -->
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+
+                            <!-- Rows: Row 0 = icon baseline, Row 1 = captions -->
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="32"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+
                             <Grid.Resources>
-                                <Style TargetType="Button">
-                                    <Setter Property="BorderThickness" Value="10" />
-                                    <Setter Property="BorderBrush" Value="Black" />
-                                    <Setter Property="HorizontalAlignment" Value="Left" />
-                                    <Setter Property="VerticalAlignment" Value="Bottom" />
-                                    <Setter Property="Width" Value="32" />
-                                    <Setter Property="Height" Value="32" />
-                                    <EventSetter Event="Click" Handler="Launch_Third"/>
+                                <!-- Launcher button -->
+                                <Style x:Key="LauncherItemButton" TargetType="Button">
+                                    <!-- Prevent MahApps background states -->
+                                    <Setter Property="OverridesDefaultStyle" Value="True"/>
+                                    <Setter Property="Background" Value="Transparent"/>
+                                    <Setter Property="BorderThickness" Value="0"/>
+                                    <Setter Property="Cursor" Value="Hand"/>
+                                    <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                                    <Setter Property="VerticalAlignment" Value="Stretch"/>
+                                    <Setter Property="Padding" Value="0"/>
+                                    <Setter Property="Template">
+                                        <Setter.Value>
+                                            <ControlTemplate TargetType="Button">
+                                                <!-- Just present the content -->
+                                                <ContentPresenter HorizontalAlignment="Center"
+                                      VerticalAlignment="Top"/>
+                                            </ControlTemplate>
+                                        </Setter.Value>
+                                    </Setter>
+                                    <EventSetter Event="Click" Handler="Launch_Click"/>
                                     <EventSetter Event="MouseEnter" Handler="MouseEnterLauncher"/>
                                     <EventSetter Event="MouseLeave" Handler="MouseLeaveLauncher"/>
                                 </Style>
-                                <Style TargetType="Label">
-                                    <Setter Property="HorizontalAlignment" Value="Left" />
-                                    <Setter Property="VerticalAlignment" Value="Bottom" />
-                                    <Setter Property="Foreground" Value="#FFF0F0F0" />
-                                    <Setter Property="HorizontalContentAlignment" Value="Center" />
-                                    <Setter Property="FontWeight" Value="Bold" />
-                                    <Setter Property="FontSize" Value="8" />
+
+                                <!-- Launcher caption -->
+                                <Style x:Key="LauncherCaptionText" TargetType="TextBlock">
+                                    <Setter Property="TextWrapping" Value="Wrap"/>
+                                    <Setter Property="TextAlignment" Value="Center"/>
+                                    <Setter Property="HorizontalAlignment" Value="Center"/>
+                                    <Setter Property="VerticalAlignment" Value="Top"/>
+                                    <Setter Property="Foreground" Value="#FFF0F0F0"/>
+                                    <Setter Property="FontWeight" Value="Bold"/>
+                                    <Setter Property="FontSize" Value="9"/>
+                                    <Setter Property="MaxWidth" Value="80"/>
+
+                                    <Style.Triggers>
+                                        <!-- Hovering the text itself -->
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter Property="Foreground" Value="{DynamicResource GridFocusedFgBrush}"/>
+                                        </Trigger>
+
+                                        <!-- Hovering anywhere on the parent Button (icon OR text) -->
+                                        <DataTrigger Value="True"
+                     Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=Button}}">
+                                            <Setter Property="Foreground" Value="{DynamicResource GridFocusedFgBrush}"/>
+                                        </DataTrigger>
+                                    </Style.Triggers>
                                 </Style>
                             </Grid.Resources>
 
-                            <Button x:Name="Launch_WDP" Margin="20,0,0,33.333">
-                                <Button.Template>
-                                    <ControlTemplate>
-                                        <Image Source="/Resources/WDP.png"/>
-                                    </ControlTemplate>
-                                </Button.Template>
+
+                            <!-- 1) Weapon Delivery Planner -->
+                            <Button x:Name="Launch_WDP"
+                Grid.Column="0" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherItemButton}"
+                Click="Launch_Third">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/WDP.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <TextBlock x:Name="Label_WDP"
+                           Text="Weapon Delivery Planner"
+                           Style="{StaticResource LauncherCaptionText}"
+                           Margin="0,4,0,0"/>
+                                </StackPanel>
                             </Button>
 
-                            <Button x:Name="Launch_MC" Margin="90,0,0,33.333">
-                                <Button.Template>
-                                    <ControlTemplate>
-                                        <Image Source="/Resources/MC.png"/>
-                                    </ControlTemplate>
-                                </Button.Template>
+                            <!-- 2) Mission Commander -->
+                            <Button x:Name="Launch_MC"
+                Grid.Column="1" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherItemButton}"
+                Click="Launch_Third">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/MC.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <TextBlock x:Name="Label_MC"
+                           Text="Mission Commander"
+                           Style="{StaticResource LauncherCaptionText}"
+                           Margin="0,4,0,0"/>
+                                </StackPanel>
                             </Button>
-                            <Button x:Name="Launch_WC" Margin="160,0,0,33.333">
-                                <Button.Template>
-                                    <ControlTemplate>
-                                        <Image Source="/Resources/WC.png"/>
-                                    </ControlTemplate>
-                                </Button.Template>
+
+                            <!-- 3) Weather Commander -->
+                            <Button x:Name="Launch_WC"
+                Grid.Column="2" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherItemButton}"
+                Click="Launch_Third">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/WC.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <TextBlock x:Name="Label_WC"
+                           Text="Weather Commander"
+                           Style="{StaticResource LauncherCaptionText}"
+                           Margin="0,4,0,0"/>
+                                </StackPanel>
                             </Button>
-                            <Button x:Name="Launch_F4WX" Margin="230,0,0,33.333">
-                                <Button.Template>
-                                    <ControlTemplate>
-                                        <Image Source="/Resources/F4WX.png"/>
-                                    </ControlTemplate>
-                                </Button.Template>
+
+                            <!-- 4) F4Wx Real Weather -->
+                            <Button x:Name="Launch_F4WX"
+                Grid.Column="3" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherItemButton}"
+                Click="Launch_Third">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/F4WX.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <TextBlock x:Name="Label_F4WX"
+                           Text="F4Wx Real Weather"
+                           Style="{StaticResource LauncherCaptionText}"
+                           Margin="0,4,0,0"/>
+                                </StackPanel>
                             </Button>
-                            <Button x:Name="Launch_F4RADAR" Margin="300,0,0,33.333">
-                                <Button.Template>
-                                    <ControlTemplate>
-                                        <Image Source="/Resources/F4RADAR.png"/>
-                                    </ControlTemplate>
-                                </Button.Template>
+
+                            <!-- 5) F4 RADAR C2 (AWACS) Tool -->
+                            <Button x:Name="Launch_F4RADAR"
+                Grid.Column="4" Grid.Row="0" Grid.RowSpan="2"
+                Style="{StaticResource LauncherItemButton}"
+                Click="Launch_Third">
+                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                    <Image Source="/Resources/F4RADAR.png" Width="32" Height="32" Stretch="Uniform"/>
+                                    <TextBlock x:Name="Label_F4RADAR"
+                           Text="F4 RADAR C2 (AWACS) Tool"
+                           Style="{StaticResource LauncherCaptionText}"
+                           Margin="0,2,0,0"/>
+                                </StackPanel>
                             </Button>
-                            <Label x:Name="Label_WDP" Content="Weapon Delivery&#10;        Planner" Margin="0,0,0,0.333"/>
-                            <Label x:Name="Label_MC" Content="    Mission&#xA;Commander" Margin="75,0,0,0.333"/>
-                            <Label x:Name="Label_WC" Content="   Weather&#xA;Commander" Margin="147,0,0,0.333"/>
-                            <Label x:Name="Label_F4WX" Content="      F4Wx&#xA;Real Weather" Margin="216,0,0,0.333"/>
-                            <Label x:Name="Label_F4RADAR" Content="     F4 RADAR&#xA;C2(AWACS) Tool" Margin="281,0,0,0.333"/>
                         </Grid>
                     </Border>
+
 
                     <Button x:Name="Launch_BMS_Large" Content="LAUNCH" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" Controls:ControlsHelper.ContentCharacterCasing="Normal" HorizontalAlignment="Right" Margin="20,20,20,20" VerticalAlignment="Bottom" Width="208" Click="Launch_Click" Height="72" Background="#CC2494FF" BorderBrush="{x:Null}" FontSize="24" Grid.Row="1"/>
                     <ListBox x:Name="ListBox_BMS" SelectionChanged="ListBox_BMS_SelectionChanged" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="20,20,240,20" Width="220" Height="72" SelectionMode="Single" d:ItemsSource="{d:SampleData ItemCount=5}" Style="{StaticResource LauncherListBox}">

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -8,7 +8,8 @@
         mc:Ignorable="d"
         Title="FalconBMS Alternative Launcher" Height="768" Width="1024" MinHeight="768" MinWidth="1024" BorderThickness="0"
         Closed="Window_Closed" MouseDown="MetroWindow_MouseDown"
-        FontSize="12" WindowStartupLocation="CenterScreen" ShowTitleBar="False" WindowStyle="None" Background="#a4a9ac" OverrideDefaultWindowCommandsBrush="#a4a9ac">
+        FontSize="12" WindowStartupLocation="CenterScreen" ShowTitleBar="False" WindowStyle="None" Background="#a4a9ac" OverrideDefaultWindowCommandsBrush="#a4a9ac"
+        xmlns:local="clr-namespace:FalconBMS.Launcher.Windows">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -188,6 +189,7 @@
 
                     </Grid>
 
+                    <!-- PRIMARY STRIP (9 items) -->
                     <Border BorderThickness="1"
         HorizontalAlignment="Left"
         Height="72"
@@ -196,153 +198,37 @@
         VerticalAlignment="Bottom"
         Style="{StaticResource LauncherStripBorder}">
 
-                        <Grid VerticalAlignment="Center">
-                            <!-- 9 columns -->
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="*"/>
-                            </Grid.ColumnDefinitions>
+                        <ItemsControl x:Name="PrimaryStripControl"
+                VerticalAlignment="Center"
+                ItemsSource="{x:Static local:LauncherCatalog.PrimaryStrip}">
 
-                            <!-- Rows: Row 0 = icons, Row 1 = labels -->
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="32"/>
-                                <RowDefinition Height="Auto"/>
-                            </Grid.RowDefinitions>
+                            <!-- Layout: 1 row, 9 columns -->
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <UniformGrid Rows="1" Columns="9"/>
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
 
-                            <Grid.Resources>
-                                <Style x:Key="LauncherButton" TargetType="Button" BasedOn="{StaticResource LauncherButtonBase}">
+                            <!-- Local wrapper style adds ONLY the Click handler -->
+                            <ItemsControl.Resources>
+                                <Style x:Key="PrimaryLauncherButton"
+             TargetType="Button"
+             BasedOn="{StaticResource LauncherStripButtonStyle}">
                                     <EventSetter Event="Click" Handler="Launch_Click"/>
-                                    <EventSetter Event="MouseEnter" Handler="MouseEnterLauncher"/>
-                                    <EventSetter Event="MouseLeave" Handler="MouseLeaveLauncher"/>
                                 </Style>
-                            </Grid.Resources>
+                            </ItemsControl.Resources>
 
-                            <!-- 1) Update -->
-                            <Button x:Name="Launch_UPD"
-                Grid.Column="0" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/UPD.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_UPD"
-                           Text="Update"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
+                            <!-- Each catalog item renders as a Button -->
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="{x:Type local:LauncherItem}">
+                                    <Button Style="{StaticResource PrimaryLauncherButton}"/>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
 
-                            <!-- 2) Config -->
-                            <Button x:Name="Launch_CFG"
-                Grid.Column="1" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/CFG.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_CFG"
-                           Text="Config"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 3) Display Config -->
-                            <Button x:Name="Launch_MMC"
-                Grid.Column="2" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/BmsMultiMon.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_MMC"
-                           Text="Display Config"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 4) RTT Client -->
-                            <Button x:Name="Launch_RTTC"
-                Grid.Column="3" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/RTTClient64.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_RTTC"
-                           Text="RTT Client"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 5) RTT Server -->
-                            <Button x:Name="Launch_RTTS"
-                Grid.Column="4" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/RTTServer64.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_RTTS"
-                           Text="RTT Server"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 6) IVC Client (MP Radio) -->
-                            <Button x:Name="Launch_IVCC"
-                Grid.Column="5" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/IVCC.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_IVCC"
-                           Style="{StaticResource LauncherLabel}">
-                    <Run Text="IVC Client"/>
-                    <LineBreak/>
-                    <Run Text="(MP Radio)"/>
-                                    </TextBlock>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 7) IVC Server (MP Radio) -->
-                            <Button x:Name="Launch_IVCS"
-                Grid.Column="6" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/IVCS.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_IVCS"
-                           Style="{StaticResource LauncherLabel}">
-                    <Run Text="IVC Server"/>
-                    <LineBreak/>
-                    <Run Text="(MP Radio)"/>
-                                    </TextBlock>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 8) Avionics Configurator -->
-                            <Button x:Name="Launch_AVC"
-                Grid.Column="7" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/AVC.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_AVC"
-                           Style="{StaticResource LauncherLabel}">
-                    <Run Text="Avionics"/>
-                    <LineBreak/>
-                    <Run Text="Configurator"/>
-                                    </TextBlock>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 9) Editor -->
-                            <Button x:Name="Launch_EDIT"
-                Grid.Column="8" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/EDIT.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_EDIT"
-                           Text="Editor"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-                        </Grid>
+                        </ItemsControl>
                     </Border>
 
+                    <!-- Third-party strip (5 items) -->
                     <Border BorderThickness="1"
         HorizontalAlignment="Left"
         Height="72"
@@ -351,90 +237,32 @@
         VerticalAlignment="Bottom"
         Style="{StaticResource LauncherStripBorder}">
 
-                        <Grid VerticalAlignment="Center">
-                            <!-- 5 columns -->
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
+                        <ItemsControl VerticalAlignment="Center"
+                ItemsSource="{x:Static local:LauncherCatalog.ThirdPartyStrip}">
+                            <!-- Layout: 1 row, 5 columns -->
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <UniformGrid Rows="1" Columns="5"/>
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
 
-                            <!-- Rows: Row 0 = icons, Row 1 = labels -->
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="32"/>
-                                <RowDefinition Height="Auto"/>
-                            </Grid.RowDefinitions>
-
-                            <Grid.Resources>
-                                <Style x:Key="LauncherButton" TargetType="Button" BasedOn="{StaticResource LauncherButtonBase}">
+                            <!-- Local wrapper style adds ONLY the Click handler -->
+                            <ItemsControl.Resources>
+                                <Style x:Key="ThirdPartyLauncherButton"
+             TargetType="Button"
+             BasedOn="{StaticResource LauncherStripButtonStyle}">
                                     <EventSetter Event="Click" Handler="Launch_Third"/>
-                                    <EventSetter Event="MouseEnter" Handler="MouseEnterLauncher"/>
-                                    <EventSetter Event="MouseLeave" Handler="MouseLeaveLauncher"/>
                                 </Style>
-                            </Grid.Resources>
+                            </ItemsControl.Resources>
 
-                            <!-- 1) Weapon Delivery Planner -->
-                            <Button x:Name="Launch_WDP"
-                Grid.Column="0" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/WDP.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_WDP"
-                           Text="Weapon Delivery Planner"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
+                            <!-- Each catalog item renders as a Button -->
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="{x:Type local:LauncherItem}">
+                                    <Button Style="{StaticResource ThirdPartyLauncherButton}"/>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
 
-                            <!-- 2) Mission Commander -->
-                            <Button x:Name="Launch_MC"
-                Grid.Column="1" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/MC.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_MC"
-                           Text="Mission Commander"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 3) Weather Commander -->
-                            <Button x:Name="Launch_WC"
-                Grid.Column="2" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/WC.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_WC"
-                           Text="Weather Commander"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 4) F4Wx Real Weather -->
-                            <Button x:Name="Launch_F4WX"
-                Grid.Column="3" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/F4WX.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_F4WX"
-                           Text="F4Wx Real Weather"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-
-                            <!-- 5) F4 RADAR C2 (AWACS) Tool -->
-                            <Button x:Name="Launch_F4RADAR"
-                Grid.Column="4" Grid.Row="0" Grid.RowSpan="2"
-                Style="{StaticResource LauncherButton}">
-                                <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                    <Image Source="/Resources/F4RADAR.png" Style="{StaticResource LauncherIcon}"/>
-                                    <TextBlock x:Name="Label_F4RADAR"
-                           Text="F4 RADAR C2 (AWACS) Tool"
-                           Style="{StaticResource LauncherLabel}"/>
-                                </StackPanel>
-                            </Button>
-                        </Grid>
+                        </ItemsControl>
                     </Border>
 
                     <Border VerticalAlignment="Top" Height="Auto" Margin="794,60,24,0" Padding="10" Width="200" Style="{StaticResource LauncherStripBorder}">

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -110,6 +110,7 @@
             VerticalAlignment="Center"
             Content="Open Docs Folder"
             FontSize="10"
+            Cursor="Hand"
             Click="OpenDocs_Click"
             Style="{StaticResource MahApps.Styles.Button.Square.Accent}"
             Controls:ControlsHelper.ContentCharacterCasing="Normal"/>
@@ -454,7 +455,7 @@
                     <ListBox x:Name="ListBox_BMS" SelectionChanged="ListBox_BMS_SelectionChanged" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="20,20,240,20" Width="220" Height="72" SelectionMode="Single" d:ItemsSource="{d:SampleData ItemCount=5}" Style="{StaticResource LauncherListBox}">
                     </ListBox>
 
-                    <Button x:Name="Launch_BMS_Large" Content="LAUNCH" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" Controls:ControlsHelper.ContentCharacterCasing="Normal" HorizontalAlignment="Right" Margin="20,20,20,20" VerticalAlignment="Bottom" Width="208" Click="Launch_Click" Height="72" Background="#CC2494FF" BorderBrush="{x:Null}" FontSize="24" Grid.Row="1"/>
+                    <Button x:Name="Launch_BMS_Large" Content="LAUNCH" Style="{StaticResource MahApps.Styles.Button.Square.Accent}" Controls:ControlsHelper.ContentCharacterCasing="Normal" HorizontalAlignment="Right" Margin="20,20,20,20" VerticalAlignment="Bottom" Width="208" Cursor="Hand" Click="Launch_Click" Height="72" Background="#CC2494FF" BorderBrush="{x:Null}" FontSize="24" Grid.Row="1"/>
 
                 </Grid>
             </TabItem>
@@ -769,7 +770,7 @@
 
                     <Label Content="* Double Click a cell to Assign keys." HorizontalContentAlignment="Right" HorizontalAlignment="Right" Margin="0,0,9.666,30.334" VerticalAlignment="Bottom" Width="596" Height="29" Foreground="{StaticResource UiForegroundBrush}" Grid.Column="1"/>
 
-                    <Button x:Name="ImportButton" Content="Import Key File..." HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="20,20,240,20" Width="129" Click="ImportKeyfile_Click" Height="27" Grid.Column="1"/>
+                    <Button x:Name="ImportButton" Content="Import Key File..." HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="20,20,240,20" Width="129" Click="ImportKeyfile_Click" Cursor="Hand" Height="27" Grid.Column="1"/>
                 </Grid>
             </TabItem>
         </TabControl>

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
@@ -491,7 +491,17 @@ namespace FalconBMS.Launcher.Windows
                     if (appReg.IsUniqueNameDefined() == false)
                         return;
                 }
-
+                // Build the legacy route key ("Launch_*") and pass a small proxy Button
+                // so existing routing code can keep working without changes.
+                var btn = sender as System.Windows.Controls.Button;
+                var id = btn?.Tag as string;
+                if (!string.IsNullOrWhiteSpace(id))
+                {
+                    var routeName = "Launch_" + id;
+                    var proxy = new System.Windows.Controls.Button { Name = routeName };
+                    appReg.getLauncher().execute(proxy);
+                    return;
+                }
                 appReg.getLauncher().execute(sender);
             }
             catch (FileNotFoundException ex)
@@ -499,6 +509,31 @@ namespace FalconBMS.Launcher.Windows
                 Diagnostics.Log(ex);
                 Diagnostics.ShowErrorMsgbox(ex);
                 Close();
+            }
+        }
+
+        // Toggle visibility of a launcher item (by Id) in the primary strip.
+        public void SetPrimaryLauncherVisible(string id, bool isVisible)
+        {
+            SetItemVisibilityInItemsControl(PrimaryStripControl, id, isVisible);
+        }
+
+        private static void SetItemVisibilityInItemsControl(System.Windows.Controls.ItemsControl ic, string id, bool isVisible)
+        {
+            if (ic == null || string.IsNullOrWhiteSpace(id)) return;
+
+            // Find the item with the matching Id
+            for (int i = 0; i < ic.Items.Count; i++)
+            {
+                if (ic.Items[i] is FalconBMS.Launcher.Windows.LauncherItem li &&
+                    string.Equals(li.Id, id, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Get the container and hide/show it
+                    var container = ic.ItemContainerGenerator.ContainerFromIndex(i) as FrameworkElement;
+                    if (container != null)
+                        container.Visibility = isVisible ? Visibility.Visible : Visibility.Collapsed;
+                    break;
+                }
             }
         }
 
@@ -558,7 +593,7 @@ namespace FalconBMS.Launcher.Windows
                 string downloadlink = "";
                 string installexe   = "";
 
-                switch (((Button)sender).Name)
+                switch ("Launch_" + (string)((Button)sender).Tag)
                 {
                     case "Launch_WDP":
                         target = "\\WeaponDeliveryPlanner.exe";
@@ -690,73 +725,6 @@ namespace FalconBMS.Launcher.Windows
                 Diagnostics.Log(ex);
                 Diagnostics.ShowErrorMsgbox(ex);
                 Close();
-            }
-        }
-
-        /// <summary>
-        /// Change label color when mouse enters one of launcher icons.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void MouseEnterLauncher(object sender, EventArgs e)
-        {
-            try
-            {
-                string nme = ((Button)sender).Name;
-
-                if (nme.Contains("Launch_"))
-                {
-                    if (nme.Contains("Launch_TheaterConfig"))
-                        return;
-                    Button tbButton = FindName(nme) as Button;
-                    if (tbButton == null)
-                        return;
-                    tbButton.BorderBrush = CommonConstants.LIGHTBLUE;
-                    tbButton.BorderThickness = new Thickness(1);
-
-                    nme = nme.Replace("Launch_", "");
-                    Label tblabel = FindName("Label_" + nme) as Label;
-                    if (tblabel == null)
-                        return;
-                    tblabel.Foreground = CommonConstants.BLUEILUM;
-                }
-            }
-            catch (Exception ex)
-            {
-                Diagnostics.Log(ex);
-            }
-        }
-
-        /// <summary>
-        /// Reset label color when mouse leaves a launcher icon.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void MouseLeaveLauncher(object sender, EventArgs e)
-        {
-            try
-            {
-                string nme = ((Button)sender).Name;
-
-                if (nme.Contains("Launch_"))
-                {
-                    if (nme.Contains("Launch_TheaterConfig"))
-                        return;
-                    Button tbButton = FindName(nme) as Button;
-                    if (tbButton == null)
-                        return;
-                    tbButton.BorderThickness = new Thickness(0);
-
-                    nme = nme.Replace("Launch_", "");
-                    Label tblabel = FindName("Label_" + nme) as Label;
-                    if (tblabel == null)
-                        return;
-                    tblabel.Foreground = CommonConstants.WHITEILUM;
-                }
-            }
-            catch (Exception ex)
-            {
-                Diagnostics.Log(ex);
             }
         }
         

--- a/Falcon BMS Alternative Launcher/Windows/RSSReader.cs
+++ b/Falcon BMS Alternative Launcher/Windows/RSSReader.cs
@@ -100,11 +100,12 @@ namespace FalconBMS.Launcher.Windows
             {
                 if (webSite != null)
                 {
-                    tb.Inlines.Add(new Run("from ") { FontStyle = FontStyles.Italic, FontSize = 12 });
-                    Hyperlink topLink = new Hyperlink() { NavigateUri = new Uri(link) };
-                    topLink.Inlines.Add(new Run(webSite.Replace("https://","")) { FontStyle = FontStyles.Italic, Foreground = new SolidColorBrush(Color.FromArgb(0x80, 0xff, 0xff, 0xff)), FontSize = 12 });
-                    topLink.RequestNavigate += Try_RequestNavigateTop;
-                    tb.Inlines.Add(topLink);
+                    tb.Inlines.Add(new Run(dateTime.ToString("MMM d, yyyy"))
+                    {
+                        FontStyle = FontStyles.Italic,
+                        FontSize = 12,
+                        Foreground = new SolidColorBrush(Color.FromArgb(0x80, 0xff, 0xff, 0xff))
+                    });
                     tb.Inlines.Add("\n");
                 }
 
@@ -117,7 +118,7 @@ namespace FalconBMS.Launcher.Windows
                 tb.Inlines.Add("\n");
 
                 Hyperlink hyperLink = new Hyperlink() {NavigateUri = new Uri(link)};
-                hyperLink.Inlines.Add(new Run(">> Read More") { Foreground = Brushes.Aquamarine, FontSize = 12 });
+                hyperLink.Inlines.Add(new Run(">> Read More") { Foreground = (Brush)Application.Current.Resources["GridFocusedFgBrush"], FontSize = 12 });
                 hyperLink.RequestNavigate += Try_RequestNavigate;
                 tb.Inlines.Add(hyperLink);
 


### PR DESCRIPTION
- Converted both launcher strips into a grid layout, then into data-driven ItemsControls
- Moved hover styling from MainWindow.xaml.cs into Styles.xaml
- Added a central LauncherCatalog for easy updating of items
- Preserve existing launch behavior
- Moved the theater, docs button, and radio buttons into grids as well
- Moved some more repeated styles into Styles.xaml
- Updated the RSS feed to display the post publish date instead of the website URL (easier to catch updates by checking the date vs remembering what was the last post title you saw) 