### PR TITLE
Gyroplatter/keep launcher open

### DIFF
--- a/Falcon BMS Alternative Launcher/App.config
+++ b/Falcon BMS Alternative Launcher/App.config
@@ -89,6 +89,9 @@
             <setting name="Misc_bExportRTTTextures" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="KeepLauncherOpen" serializeAs="String">
+                <value>False</value>
+            </setting>
         </FalconBMS.Launcher.Properties.Settings>
         <FalconBMS_Alternative_Launcher_Cs.Properties.Settings>
             <setting name="Platform" serializeAs="String">

--- a/Falcon BMS Alternative Launcher/AppProperties.cs
+++ b/Falcon BMS Alternative Launcher/AppProperties.cs
@@ -21,6 +21,7 @@ namespace FalconBMS.Launcher
             mainWindow.CMD_EF.IsOn          = Properties.Settings.Default.CMD_EF;
             mainWindow.CMD_MONO.IsOn        = Properties.Settings.Default.CMD_MONO;
 
+            mainWindow.KeepLauncherOpen.IsChecked          = Properties.Settings.Default.KeepLauncherOpen;
             mainWindow.ApplicationOverride.IsChecked       = Properties.Settings.Default.NoOverride;
 
             mainWindow.Misc_RollLinkedNWS.IsChecked        = Properties.Settings.Default.Misc_RLNWS;
@@ -86,6 +87,7 @@ namespace FalconBMS.Launcher
             Properties.Settings.Default.CMD_EF                    = (bool)mainWindow.CMD_EF.IsOn;
             Properties.Settings.Default.CMD_MONO                  = (bool)mainWindow.CMD_MONO.IsOn;
 
+            Properties.Settings.Default.KeepLauncherOpen          = (bool)mainWindow.KeepLauncherOpen.IsChecked;
             Properties.Settings.Default.NoOverride                = (bool)mainWindow.ApplicationOverride.IsChecked;
             
             Properties.Settings.Default.Misc_RLNWS                = (bool)mainWindow.Misc_RollLinkedNWS.IsChecked;

--- a/Falcon BMS Alternative Launcher/Properties/Settings.Designer.cs
+++ b/Falcon BMS Alternative Launcher/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace FalconBMS.Launcher.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.10.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.14.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -332,6 +332,18 @@ namespace FalconBMS.Launcher.Properties {
             }
             set {
                 this["Misc_bExportRTTTextures"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool KeepLauncherOpen {
+            get {
+                return ((bool)(this["KeepLauncherOpen"]));
+            }
+            set {
+                this["KeepLauncherOpen"] = value;
             }
         }
     }

--- a/Falcon BMS Alternative Launcher/Properties/Settings.settings
+++ b/Falcon BMS Alternative Launcher/Properties/Settings.settings
@@ -80,5 +80,8 @@
     <Setting Name="Misc_bExportRTTTextures" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="KeepLauncherOpen" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Falcon BMS Alternative Launcher/Starter/Starter432.cs
+++ b/Falcon BMS Alternative Launcher/Starter/Starter432.cs
@@ -26,6 +26,7 @@ namespace FalconBMS.Launcher.Starter
                     process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Updater.exe");
                     mainWindow.Close();
                     break;
+
                 case "Launch_BMS_Large":
                     string strCmdText = getCommandLine();
 
@@ -35,8 +36,19 @@ namespace FalconBMS.Launcher.Starter
                     string bmsExe = appReg.GetInstallDir() + "/Bin/x86/Falcon BMS.exe";
                     process = Utils.LaunchProcess(bmsExe, strCmdText);
                     MainWindow.bmsHasBeenLaunched = true;
-                    mainWindow.Close();
+
+                    if (Properties.Settings.Default.KeepLauncherOpen)
+                    {
+                        // Stay open: minimize while BMS runs, then restore on exit
+                        mainWindow.minimizeWindowUntilProcessEnds(process);
+                    }
+                    else
+                    {
+                        // Default behavior: close after launching BMS
+                        mainWindow.Close();
+                    }
                     break;
+
                 case "Launch_CFG":
                     process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Config.exe");
                     mainWindow.minimizeWindowUntilProcessEnds(process);

--- a/Falcon BMS Alternative Launcher/Starter/Starter433.cs
+++ b/Falcon BMS Alternative Launcher/Starter/Starter433.cs
@@ -29,6 +29,7 @@ namespace FalconBMS.Launcher.Starter
                     process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Updater.exe");
                     mainWindow.Close();
                     break;
+
                 case "Launch_BMS_Large":
                     string strCmdText = getCommandLine();
 
@@ -41,8 +42,19 @@ namespace FalconBMS.Launcher.Starter
 
                     process = Utils.LaunchProcess(bmsExe, strCmdText);
                     MainWindow.bmsHasBeenLaunched = true;
-                    mainWindow.Close();
+
+                    if (Properties.Settings.Default.KeepLauncherOpen)
+                    {
+                        // Stay open: minimize while BMS runs, then restore on exit
+                        mainWindow.minimizeWindowUntilProcessEnds(process);
+                    }
+                    else
+                    {
+                        // Default behavior: close after launching BMS
+                        mainWindow.Close();
+                    }
                     break;
+
                 case "Launch_CFG":
                     process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Config.exe");
                     mainWindow.minimizeWindowUntilProcessEnds(process);

--- a/Falcon BMS Alternative Launcher/Starter/Starter434.cs
+++ b/Falcon BMS Alternative Launcher/Starter/Starter434.cs
@@ -29,6 +29,7 @@ namespace FalconBMS.Launcher.Starter
                     process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Updater.exe");
                     mainWindow.Close();
                     break;
+
                 case "Launch_BMS_Large":
                     string strCmdText = getCommandLine();
 
@@ -38,8 +39,19 @@ namespace FalconBMS.Launcher.Starter
                     string bmsExe = appReg.GetInstallDir() + "/Bin/x64/Falcon BMS.exe";
                     process = Utils.LaunchProcess(bmsExe, strCmdText);
                     MainWindow.bmsHasBeenLaunched = true;
-                    mainWindow.Close();
+
+                    if (Properties.Settings.Default.KeepLauncherOpen)
+                    {
+                        // Stay open: minimize while BMS runs, then restore on exit
+                        mainWindow.minimizeWindowUntilProcessEnds(process);
+                    }
+                    else
+                    {
+                        // Default behavior: close after launching BMS
+                        mainWindow.Close();
+                    }
                     break;
+
                 case "Launch_CFG":
                     process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Config.exe");
                     mainWindow.minimizeWindowUntilProcessEnds(process);

--- a/Falcon BMS Alternative Launcher/Starter/Starter435.cs
+++ b/Falcon BMS Alternative Launcher/Starter/Starter435.cs
@@ -29,6 +29,7 @@ namespace FalconBMS.Launcher.Starter
                     process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Updater.exe");
                     mainWindow.Close();
                     break;
+
                 case "Launch_BMS_Large":
                     string strCmdText = getCommandLine();
 
@@ -36,7 +37,8 @@ namespace FalconBMS.Launcher.Starter
                     mainWindow.executeOverride();
 
                     string testPlatform = appReg.GetInstallDir() + "/Bin/x64/Falcon BMS Test.exe";
-                    if (File.Exists(testPlatform) && MessageBox.Show(Program.mainWin, "Start Test Exe?", "Launcher", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
+                    if (File.Exists(testPlatform) &&
+                        MessageBox.Show(Program.mainWin, "Start Test Exe?", "Launcher", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
                     {
                         process = Utils.LaunchProcess(testPlatform, strCmdText);
                         MainWindow.bmsHasBeenLaunched = true;
@@ -47,8 +49,19 @@ namespace FalconBMS.Launcher.Starter
                         process = Utils.LaunchProcess(bmsExe, strCmdText);
                         MainWindow.bmsHasBeenLaunched = true;
                     }
-                    mainWindow.Close();
+
+                    if (Properties.Settings.Default.KeepLauncherOpen)
+                    {
+                        // Stay open: minimize while BMS runs, then restore on exit
+                        mainWindow.minimizeWindowUntilProcessEnds(process);
+                    }
+                    else
+                    {
+                        // Default behavior: close after launching BMS
+                        mainWindow.Close();
+                    }
                     break;
+
                 case "Launch_CFG":
                     process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Config.exe");
                     mainWindow.minimizeWindowUntilProcessEnds(process);

--- a/Falcon BMS Alternative Launcher/Starter/Starter436I.cs
+++ b/Falcon BMS Alternative Launcher/Starter/Starter436I.cs
@@ -29,6 +29,7 @@ namespace FalconBMS.Launcher.Starter
                     process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Updater.exe");
                     mainWindow.Close();
                     break;
+
                 case "Launch_BMS_Large":
                     string strCmdText = getCommandLine();
 
@@ -38,8 +39,19 @@ namespace FalconBMS.Launcher.Starter
                     string bmsExe = appReg.GetInstallDir() + "/Bin/x64/Falcon BMS.exe";
                     process = Utils.LaunchProcess(bmsExe, strCmdText);
                     MainWindow.bmsHasBeenLaunched = true;
-                    mainWindow.Close();
+
+                    if (Properties.Settings.Default.KeepLauncherOpen)
+                    {
+                        // Stay open: minimize while BMS runs, then restore on exit
+                        mainWindow.minimizeWindowUntilProcessEnds(process);
+                    }
+                    else
+                    {
+                        // Default behavior: close after launching BMS
+                        mainWindow.Close();
+                    }
                     break;
+
                 case "Launch_CFG":
                     process = Utils.LaunchProcess(appReg.GetInstallDir() + "/Config.exe");
                     mainWindow.minimizeWindowUntilProcessEnds(process);

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -149,7 +149,11 @@
                             <Label x:Name="Label_EDIT" Content="Editor&#xD;&#xA;" Margin="575,0,0,0"/>
                         </Grid>
                     </Border>
-                    <CheckBox x:Name="ApplicationOverride" Content="Launch without applying overrides" HorizontalAlignment="Right" Margin="0,0,20,98" MinWidth="206" VerticalAlignment="Bottom" Background="#FFECFF71" Foreground="{StaticResource UiForegroundBrush}" />
+                    
+                    <CheckBox x:Name="KeepLauncherOpen" Content="Open Launcher after exiting BMS" 
+                              HorizontalAlignment="Right" Margin="0,0,20,123" MinWidth="206" VerticalAlignment="Bottom" Background="#FFECFF71" Foreground="{StaticResource UiForegroundBrush}" />
+                    <CheckBox x:Name="ApplicationOverride" Content="Launch without applying overrides" 
+                              HorizontalAlignment="Right" Margin="0,0,20,98" MinWidth="206" VerticalAlignment="Bottom" Background="#FFECFF71" Foreground="{StaticResource UiForegroundBrush}" />
 
                     <Border BorderThickness="1" HorizontalAlignment="Left" Height="72" Margin="48,0,0,20" VerticalAlignment="Bottom" Width="480" Style="{StaticResource LauncherStripBorder}">
                         <Grid HorizontalAlignment="Stretch" Height="auto" Margin="0,0,0,0" VerticalAlignment="Stretch" Width="auto">

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml
@@ -150,8 +150,8 @@
                         </Grid>
                     </Border>
                     
-                    <CheckBox x:Name="KeepLauncherOpen" Content="Open Launcher after exiting BMS" 
-                              HorizontalAlignment="Right" Margin="0,0,20,123" MinWidth="206" VerticalAlignment="Bottom" Background="#FFECFF71" Foreground="{StaticResource UiForegroundBrush}" />
+                    <CheckBox x:Name="KeepLauncherOpen" Content="Reopen Launcher after exiting BMS" 
+                              HorizontalAlignment="Right" Margin="0,0,17,124" MinWidth="206" VerticalAlignment="Bottom" Background="#FFECFF71" Foreground="{StaticResource UiForegroundBrush}" />
                     <CheckBox x:Name="ApplicationOverride" Content="Launch without applying overrides" 
                               HorizontalAlignment="Right" Margin="0,0,20,98" MinWidth="206" VerticalAlignment="Bottom" Background="#FFECFF71" Foreground="{StaticResource UiForegroundBrush}" />
 

--- a/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
+++ b/Falcon BMS Alternative Launcher/Windows/MainWindow.xaml.cs
@@ -484,6 +484,9 @@ namespace FalconBMS.Launcher.Windows
         {
             try
             {
+                // Save UI Properties(Like Button Status)
+                appProperties.SaveUISetup();
+
                 if (appReg.IsUniqueNameDefined() == false)
                 {
                     CallsignWindow.ShowCallsignWindow(appReg);


### PR DESCRIPTION
Added a new checkbox to minimize the Launcher after clicking 'Launch', and restore it after exiting Falcon BMS.exe.

SaveUISetup() is now also run on launch click, just in case users make changes without running BMS. 